### PR TITLE
FAQsslHandshake - Fix truncation

### DIFF
--- a/site/content/faq/how-to-connect-to-an-https-site-that-reports-a-handshake-failure.md
+++ b/site/content/faq/how-to-connect-to-an-https-site-that-reports-a-handshake-failure.md
@@ -64,4 +64,4 @@ Group](https://groups.google.com/forum/#!forum/zaproxy-users).
 
 The error and the likely cause is described in
 [#2626](https://github.com/zaproxy/zaproxy/issues/2626): Java 8 does not
-support DH parameters with more than 2048 bit. It works with Java 9 (Debian:
+support DH parameters with more than 2048 bit. It works with Java 9 (Debian: Install `openjdk-9-jre`).


### PR DESCRIPTION
Restoring final tip, per:
https://github.com/zaproxy/zaproxy/wiki/FAQsslHandshake/64e7520f55439af6b9d6e7a401b5febb7160a33b

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
