### PR TITLE
Link to site blog posts

### DIFF
--- a/site/content/blog/2014-03-10-hacking-zap-1-why-should-you/index.md
+++ b/site/content/blog/2014-03-10-hacking-zap-1-why-should-you/index.md
@@ -72,6 +72,5 @@ project to people who might otherwise never have known about it or bothered to t
 
 ZAP is open source, and will stay open source. You will never have to pay for a ‘pro’ version. However we have no problem with people developing
 and selling closed source add-ons to ZAP. If you think you can make money from selling ZAP add-ons then go for it.  
-The next post in this [series](http://code.google.com/p/zaproxy/wiki/Development#Hacking_ZAP) is: [Hacking ZAP #2 - Getting started
-](http://zaproxy.blogspot.co.uk/2014/03/hacking-zap-2-getting-started.html)
+The next post in this [series](http://code.google.com/p/zaproxy/wiki/Development#Hacking_ZAP) is: [Hacking ZAP #2 - Getting started](/blog/2014-03-20-hacking-zap-2-getting-started/)
 

--- a/site/content/blog/2014-03-20-hacking-zap-2-getting-started/index.md
+++ b/site/content/blog/2014-03-20-hacking-zap-2-getting-started/index.md
@@ -10,7 +10,7 @@ authors:
 ---
 Welcome to a [series of blog posts](http://code.google.com/p/zaproxy/wiki/Development?ts=1394453042&updated=Development#Hacking_ZAP) aimed at
 helping you “hack the ZAP source code”.  
-The previous post in this series is: [Hacking ZAP #1 - Why should you?](http://zaproxy.blogspot.com/2014/03/hacking-zap-1-why-should-you.html)  
+The previous post in this series is: [Hacking ZAP #1 - Why should you?](/blog/2014-03-10-hacking-zap-1-why-should-you/)  
   
 In order to change the ZAP source code you will need to set up a development environment.  
   
@@ -136,6 +136,5 @@ We will cover all of these components (and more) in more detail in a future post
 If you have any questions about ZAP development then please ask them on the [ZAP Developer](http://groups.google.com/group/zaproxy-develop)
 group.  
   
-The next post in this series is: [Hacking ZAP #3: Passive scan rules](http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-
-rules.html)
+The next post in this series is: [Hacking ZAP #3: Passive scan rules](/blog/2014-04-03-hacking-zap-3-passive-scan-rules/)
 

--- a/site/content/blog/2014-04-03-hacking-zap-3-passive-scan-rules/index.md
+++ b/site/content/blog/2014-04-03-hacking-zap-3-passive-scan-rules/index.md
@@ -10,8 +10,7 @@ authors:
 ---
 Welcome to a [series of blog posts](https://github.com/zaproxy/zaproxy/wiki/Development#Hacking_ZAP) aimed at helping you “hack the ZAP source
 code”.  
-The previous post in this series is: [Hacking ZAP #2 - Getting Started](http://zaproxy.blogspot.co.uk/2014/03/hacking-zap-2-getting-
-started.html)  
+The previous post in this series is: [Hacking ZAP #2 - Getting Started](/blog/2014-03-20-hacking-zap-2-getting-started/)  
   
 One of the easiest ways to enhance ZAP is to write new passive scan rules.  
 Passive scan rules are used to warn the user of potential vulnerabilities that can be detected passively - they are not allowed to make any new
@@ -171,5 +170,5 @@ It also uses it when it downloads add-ons from the ZAP Marketplace, and adding y
 remove your rules dynamically.  
   
 A future post will cover how to contribute your code back to the ZAP community and progress it from alpha to beta and then release status.  
-The next post in this series is: [Hacking ZAP #4: Active scan rules](http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active-scan-rules.html)
+The next post in this series is: [Hacking ZAP #4: Active scan rules](/blog/2014-04-30-hacking-zap-4-active-scan-rules/)
 

--- a/site/content/blog/2014-04-30-hacking-zap-4-active-scan-rules/index.md
+++ b/site/content/blog/2014-04-30-hacking-zap-4-active-scan-rules/index.md
@@ -9,8 +9,7 @@ authors:
     - simon
 ---
 Welcome to a [series of blog posts](https://github.com/zaproxy/zaproxy/wiki/Development) aimed at helping you “hack the ZAP source code”.  
-The previous post in this series is: [Hacking ZAP #3 - Passive scan rules](http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-
-rules.html)  
+The previous post in this series is: [Hacking ZAP #3 - Passive scan rules](/blog/2014-04-03-hacking-zap-3-passive-scan-rules/)  
   
 Active scan rules are another relatively simple way to enhance ZAP. Active scan rules attack the server, and therefore are only run when
 explicitly invoked by the user. You should only use active scan rules against applications that you have permission to attack.  

--- a/site/content/blog/2015-11-02-zap-newsletter-2015-november/index.md
+++ b/site/content/blog/2015-11-02-zap-newsletter-2015-november/index.md
@@ -23,8 +23,8 @@ Oh, and please let us know what you think of this newsletter via the [Feedback F
 The big news this month is that we will be releasing **ZAP 2.4.3** very soon, ie hopefully in the first week of November. This will be an
 enhancement and bug fix release, and as always we recommend you update asap.  
   
-In other news, I ran the first online ZAP Q&A; session last month. You can listen to a recording of it here:
-<http://zaproxy.blogspot.com/2015/10/zap-q-session-tuesday-13th-octobr-2015.html>  
+In other news, I ran the first online ZAP Q&A; session last month. You can listen to a recording of it
+[here](/blog/2015-10-06-zap-q-a-session-tuesday-13th-october-2015/).  
 If you do listen to it then please fill out the feedback form linked off that page.  
   
 

--- a/site/content/blog/2016-08-22-announcing-zap-unit-test-bounties/index.md
+++ b/site/content/blog/2016-08-22-announcing-zap-unit-test-bounties/index.md
@@ -21,7 +21,7 @@ We do already have some release quality unit tests in the corresponding test pac
   * [org.zaproxy.zap.extension.pscanrules](https://github.com/zaproxy/zap-extensions/tree/master/test/org/zaproxy/zap/extension/pscanrules)
 
 These can be used as a basis of the new tests. Unit tests should be included for real issues (true positives) as well as false positives.  
-For details of how passive scan rules work see the blog post: [Hacking ZAP #3 Passive Scan Rules](https://zaproxy.blogspot.com/2014/04/hacking-zap-3-passive-scan-rules.html)  
+For details of how passive scan rules work see the blog post: [Hacking ZAP #3 Passive Scan Rules](/blog/2014-04-03-hacking-zap-3-passive-scan-rules/)  
   
 We have raised issues for all of the release and beta quality passive scan rules that do not have unit tests, and assigned a bounty on them in
 Bounty Source. The bounties vary based on the amount of work we expect will be required. We will increase the bounties paid if the pull request

--- a/site/content/blog/2017-06-19-scanning-apis-with-zap/index.md
+++ b/site/content/blog/2017-06-19-scanning-apis-with-zap/index.md
@@ -7,7 +7,7 @@ date: "2017-06-19"
 authors:
     - simon
 ---
-The previous ZAP blog post explained how you could [Explore APIs with ZAP](https://zaproxy.blogspot.com/2017/04/exploring-apis-with-zap.html).  
+The previous ZAP blog post explained how you could [Explore APIs with ZAP](/blog/2017-04-03-exploring-apis-with-zap/).  
 This blog post goes one step further, and explains how you can both explore and perform security scanning of APIs using ZAP from the command
 line.  
 This allows you to easily automate the scanning of your APIs.  

--- a/site/content/docs/desktop/addons/active-scan-rules-alpha/_index.md
+++ b/site/content/docs/desktop/addons/active-scan-rules-alpha/_index.md
@@ -16,7 +16,7 @@ The following alpha quality active scan rules are included in this add-on:
 ## An example active scan rule which loads data from a file
 
 This implements an example active scan rule that loads strings from a file that the user can edit.  
-For more details see: [Hacking ZAP Part 4: Active Scan Rules.](http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active-scan-rules.html)
+For more details see: [Hacking ZAP Part 4: Active Scan Rules](/blog/2014-04-30-hacking-zap-4-active-scan-rules/).
 
 Latest code: [ExampleFileActiveScanner.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java)
 
@@ -36,7 +36,7 @@ Latest code: [EnvFileScanner.java](https://github.com/zaproxy/zap-extensions/blo
 ## Example Active Scanner: Denial of Service
 
 This implements a very simple example active scan rule.  
-For more details see: [Hacking ZAP Part 4: Active Scan Rules.](http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active-scan-rules.html)
+For more details see: [Hacking ZAP Part 4: Active Scan Rules](/blog/2014-04-30-hacking-zap-4-active-scan-rules/).
 
 Latest code: [ExampleSimpleActiveScanner.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java)
 

--- a/site/content/docs/desktop/addons/passive-scan-rules-alpha/_index.md
+++ b/site/content/docs/desktop/addons/passive-scan-rules-alpha/_index.md
@@ -16,7 +16,7 @@ The following alpha quality passive scan rules are included in this add-on:
 ## An example passive scan rule which loads data from a file
 
 This implements an example passive scan rule that loads strings from a file that the user can edit.  
-For more details see: http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
+For more details see: [Hacking ZAP Part 3: Passive Scan Rules](/blog/2014-04-03-hacking-zap-3-passive-scan-rules/).
 
 Latest code: [ExampleFilePassiveScanner.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanner.java)
 
@@ -43,7 +43,7 @@ Latest code: [CacheableScanner.java](https://github.com/zaproxy/zap-extensions/b
 ## Example Passive Scanner: Denial of Service
 
 This implements a very simple example passive scan rule.  
-For more details see: http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
+For more details see: [Hacking ZAP Part 3: Passive Scan Rules](/blog/2014-04-03-hacking-zap-3-passive-scan-rules/).
 
 Latest code: [ExampleSimplePassiveScanner.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanner.java)
 

--- a/site/content/faq/how-can-I-add-my-own-payloads-to-active-scan-rules.md
+++ b/site/content/faq/how-can-I-add-my-own-payloads-to-active-scan-rules.md
@@ -12,6 +12,6 @@ The payloads are targetted based on the responses to other payloads so that it h
 However there a various options:
 
 1. Try out the [custom payloads](/docs/desktop/addons/custom-payloads/) add-on which is supported by some of the existing rules 
-1. Change the existing rules to improve them - this blog post is a good place to start: [Hacking ZAP: Active Scan Rules](https://zaproxy.blogspot.com/2014/04/hacking-zap-4-active-scan-rules.html) - if you do improve them then please submit pull requests :)
+1. Change the existing rules to improve them - this blog post is a good place to start: [Hacking ZAP: Active Scan Rules](/blog/2014-04-30-hacking-zap-4-active-scan-rules/) - if you do improve them then please submit pull requests :)
 1. Write new rules to do whatever you want - this gives you full control, but could be a bit daunting to start with
 1. Tweak the [User defined attacks.js](https://github.com/zaproxy/community-scripts/blob/master/active/User%20defined%20attacks.js) script - this is probably the easiest way to get started

--- a/site/content/faq/how-can-you-use-zap-to-scan-apis.md
+++ b/site/content/faq/how-can-you-use-zap-to-scan-apis.md
@@ -24,4 +24,4 @@ If you dont have any of these things then post to the [ZAP User
 Group](https://groups.google.com/group/zaproxy-users) explaining what you are
 trying to do and the problems you are having.
 
-For more details see this blog post: <https://zaproxy.blogspot.com/2017/06/scanning-apis-with-zap.html>
+For more details see the blog post [Scanning APIs with ZAP](/blog/2017-06-19-scanning-apis-with-zap/).

--- a/site/layouts/post/single.html
+++ b/site/layouts/post/single.html
@@ -4,7 +4,7 @@
     <div class="flex latest-versions">
       <article class="col-2-3 pr-30 content single-post">
           <div class="breadcrumbs">
-              <a href="/blog">The ZAP Blog</a>
+              <a href="/blog/">The ZAP Blog</a>
           </div>
 
           <h1 class="post-title">{{ .Title }}</h1>


### PR DESCRIPTION
Link to blog posts in the site instead of blogspot.
Add missing slash to blog's breadcrumb to avoid redirect.