### PR TITLE
Add data-no-csrf attribute to search form

### DIFF
--- a/site/layouts/page/search.html
+++ b/site/layouts/page/search.html
@@ -9,7 +9,7 @@
 </section>
 <section class="wrapper py-70" data-kind="{{ .Kind }}">
   <article class="content single-default">
-    <form>
+    <form data-no-csrf>
       <input type="text" name="q" id="search-filter" placeholder="Search ..." />
       <button type="button" id="search-trigger">Search</button>
     </form>


### PR DESCRIPTION
As per https://github.com/mozilla-services/websec-check
This will allow us to easily whitelist it in ZAP scans

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
