### PR TITLE
Update Slack Invite Redirect

### DIFF
--- a/site/content/redirects/slack/invite.md
+++ b/site/content/redirects/slack/invite.md
@@ -2,5 +2,5 @@
 title: Slack Invite
 layout: redirect
 url: /slack/invite
-redirect: http://owaspslack.com
+redirect: https://owasp-slack.herokuapp.com/
 ---


### PR DESCRIPTION
Use the new: https://owasp-slack.herokuapp.com/

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>