### PR TITLE
Allow to link to source content

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -7,6 +7,11 @@ enableEmoji: true
 taxonomies:
   tag: "tags"
 
+params:
+  EditContent:
+    BaseUrl: https://github.com/zaproxy/zaproxy-website/blob/master/site/content/
+    Label: Edit on GitHub
+
 # Menu
 menu:
   nav:

--- a/site/content/docs/guides/_index.md
+++ b/site/content/docs/guides/_index.md
@@ -2,4 +2,6 @@
 title: Guides
 layout: redirect
 redirect: /docs/
+cascade:
+  EditableContent: true
 ---

--- a/site/content/faq/_index.md
+++ b/site/content/faq/_index.md
@@ -1,3 +1,6 @@
 ---
 title: "Frequently Asked Questions"
+cascade:
+   EditableContent: true
+EditableContent: false
 ---

--- a/site/content/getting-started/index.md
+++ b/site/content/getting-started/index.md
@@ -2,6 +2,7 @@
 title: "Getting Started"
 tags:
 - tutorial
+EditableContent: true
 ---
 
 ### Overview

--- a/site/layouts/partials/edit-content.html
+++ b/site/layouts/partials/edit-content.html
@@ -1,0 +1,8 @@
+{{ if .Params.EditableContent | and .File }}
+{{ $baseUrl := .Params.EditBaseUrl | default .Site.Params.EditContent.BaseUrl }}
+{{ $filePath := .Params.EditFilePath | default .File.Path }}
+{{ $label := .Params.EditLabel | default .Site.Params.EditContent.Label }}
+  <div class="ml-10">
+    <a href="{{ $baseUrl }}{{ $filePath }}">{{ $label }}</a>
+  </div>
+{{ end }}

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -1,34 +1,33 @@
 <footer class="site-footer py-20 mt-20">
   <div class="wrapper flex jc-sb">
-    <div class="flex">
+    <div class="flex ai-c">
     <div class="footer-logo"><svg xmlns="http://www.w3.org/2000/svg" width="55px" viewBox="0 0 77.58 77.61"><path d="M49.48 21.64a3.46 3.46 0 0 1 .44 3 3.38 3.38 0 0 1-2.16 2.14l-1.17.38 10.74 13.56a3.39 3.39 0 0 1-1.83 5.41l-2 .5L68 65A37.78 37.78 0 0 0 39.85 2c-1.34 0-2.66.07-4 .2zM23.33 48.26a3.4 3.4 0 0 1 .45-6.09L25 41.7l-13.81-10a3.4 3.4 0 0 1 .62-5.86l.2-.09-5.47-3.84a37.79 37.79 0 0 0 55.32 48.6z" fill="#fff"/><path d="M67.84 69.48L49 45.59a.55.55 0 0 1 .28-.87l5.55-1.36a.58.58 0 0 0 .23-.13.48.48 0 0 0 .09-.11.62.62 0 0 0 .08-.24.58.58 0 0 0 0-.26.54.54 0 0 0-.07-.13L42.29 26.37a.75.75 0 0 1-.07-.12.55.55 0 0 1 .31-.74l4.35-1.4a.54.54 0 0 0 .26-.83L30.92.22a.5.5 0 0 0-.61-.22L.32 13a.55.55 0 0 0-.1.94l16.72 11.88a.52.52 0 0 1 .22.49.45.45 0 0 1-.09.26.48.48 0 0 1-.09.11l-.13.08-3.93 1.72a.55.55 0 0 0-.29.31v.13a.59.59 0 0 0 .22.5l8.62 6.22 8.61 6.21a.55.55 0 0 1 0 .87.57.57 0 0 1-.13.08l-5.11 2a.55.55 0 0 0-.28.75.56.56 0 0 0 .21.22l42.43 24.5a.53.53 0 0 0 .64-.79z" fill="#fff"/></svg></div>
-    <nav class="footer-nav">
-      <ul class="flex">        
-      {{ $currentPage := . }}
-      {{ range .Site.Menus.footer }}
-        {{ if .HasChildren }}
-          <li class="ml-10">
-            <a href="{{ .URL }}" title="{{ .Name }} page">
-              {{ .Name }}
-            </a>
-            <ul class="sub-menu p-0">
-              {{ range .Children }}
-                <li>
-                  <a href="{{ .URL }}">{{ .Name }}</a>
-                </li>
-              {{ end }}
-            </ul>
-          </li>
-        {{ else }}
-          <li class="ml-10">
-            <a href="{{ .URL }}" title="{{ .Name }} page">
-              {{ .Name }}
-            </a>
-          </li>
+    <div class="footer-left">
+      <nav class="footer-nav">
+        <ul class="flex">
+        {{ $currentPage := . }}
+        {{ range .Site.Menus.footer }}
+          {{ if .HasChildren }}
+            <li class="ml-10">
+              <a href="{{ .URL }}" title="{{ .Name }} page">
+                {{ .Name }}
+              </a>
+              <ul class="sub-menu p-0">
+                {{ range .Children }}
+                  <li>
+                    <a href="{{ .URL }}">{{ .Name }}</a>
+                  </li>
+                {{ end }}
+              </ul>
+            </li>
+          {{ else }}
+            <li class="ml-10"><a href="{{ .URL }}" title="{{ .Name }} page">{{ .Name }}</a></li>
+          {{ end }}
         {{ end }}
-      {{ end }}
-      </ul>
-    </nav>
+        </ul>
+      </nav>
+      {{ partial "edit-content" . }}
+    </div>
   </div>
 
     <div class="flex ai-c">

--- a/src/css/_footer.scss
+++ b/src/css/_footer.scss
@@ -11,6 +11,14 @@
   color: #fff;
 }
 
+.footer-left {
+  margin-left: 25px;
+
+  ul {
+    padding-left: 0;
+  }
+}
+
 .footer-social li {
   width: 47px;
   height: 47px;


### PR DESCRIPTION
Allow pages to opt in to link to source (for edition), a link is shown
in the footer. The pages can override the label, base URL, and file path
(e.g. for help pages which live in other repos).
Enable for FAQ, guides, and Getting Started.

Part of #24 - Edit me on GitHub