### PR TITLE
Link to source of blog posts

### DIFF
--- a/site/content/blog/_index.md
+++ b/site/content/blog/_index.md
@@ -1,3 +1,6 @@
 ---
 title: "The ZAP Blog"
+cascade:
+   EditableContent: true
+EditableContent: false
 ---


### PR DESCRIPTION
To allow to easily fix a typo or broken link.

Part of #24 - Enable "Edit on GitHub" in more pages