### PR TITLE
Update links

### DIFF
--- a/site/content/docs/desktop/_index.md
+++ b/site/content/docs/desktop/_index.md
@@ -41,5 +41,5 @@ ZAP is a fork of the open source variant of the [Paros Proxy](/docs/desktop/paro
 
 |   |                                                                           |
 |---|---------------------------------------------------------------------------|
-|   | [ZAP homepage](https://www.owasp.org/index.php/ZAP)                       |
+|   | [OWASP ZAP homepage](https://owasp.org/www-project-zap/)                  |
 |   | [Wikipedia entry for proxies](https://en.wikipedia.org/wiki/Proxy_server) |

--- a/site/content/docs/desktop/credits.md
+++ b/site/content/docs/desktop/credits.md
@@ -154,7 +154,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 
 ## ZAP Localization
 
-ZAP localization is organized via <https://crowdin.net/project/owasp-zap>   
+ZAP localization is organized via <https://crowdin.com/project/owasp-zap>   
 
 |   |                      |                                                                                                                                                                                                                                                                                                                                                                                          |
 |---|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/site/content/docs/desktop/releases/1.1.0.md
+++ b/site/content/docs/desktop/releases/1.1.0.md
@@ -14,7 +14,7 @@ The following changes were made in this release:
 ### OWASP rebranding
 
 ZAP has been accepted as an OWASP project.  
-Its homepage is now: https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project
+Its homepage is now: https://owasp.org/www-project-zap/
 
 ### Brute Force
 

--- a/site/content/docs/desktop/releases/2.3.0.md
+++ b/site/content/docs/desktop/releases/2.3.0.md
@@ -51,7 +51,7 @@ The API has been extended to support even more of the ZAP functionality.
 
 ### Internationalized help file
 
-The help file has been internationalized and is in the process of being translated into many other languages via <https://crowdin.net/project/owasp-zap-help>. If you use ZAP in one of the many languages we support, then the help files will include all of the available translations for that language while defaulting back to English for phrases that have not yet been translated.  
+The help file has been internationalized and is in the process of being translated into many other languages via <https://crowdin.com/project/owasp-zap-help>. If you use ZAP in one of the many languages we support, then the help files will include all of the available translations for that language while defaulting back to English for phrases that have not yet been translated.  
 Languages with a significant amount of translated help pages include:
 
 * Bosnian
@@ -72,7 +72,7 @@ Most of the UI lists have also been converted to tables, which allow you to chan
 ### More functionality moved to add-ons
 
 More of the core functionality has been moved into add-ons which allows us to deliver updates dynamically via the ZAP Marketplace rather than requiring new full releases.  
-This includes the language packs, so translations made to the ZAP UI via https://crowdin.net/project/owasp-zap can be downloaded within ZAP or even automatically installed.
+This includes the language packs, so translations made to the ZAP UI via https://crowdin.com/project/owasp-zap can be downloaded within ZAP or even automatically installed.
 
 ### New and improved active and passive scanning rules
 

--- a/site/content/docs/desktop/releases/2.4.0.md
+++ b/site/content/docs/desktop/releases/2.4.0.md
@@ -131,7 +131,7 @@ Please be aware that the Plugin ID for the External Redirect scanner has changed
 * Issue 1325 : Option to delete contexts
 * Issue 1326 : Move Ajax Spider Extension from Beta to Release status
 * Issue 1333 : ExtensionAntiCSRF ConcurrentModificationException
-* Issue 1334 : ZAP does not handle API requests on reused connections leading to UnknownHostException: www.zap.com
+* Issue 1334 : ZAP does not handle API requests on reused connections leading to `UnknownHostException: www.zap.com`
 * Issue 1335 : NullPointerException while selecting a node in the "Alerts" tab after excluding sites from proxy
 * Issue 1339 : Introduce a simple event bus
 * Issue 1343 : XContentTypeOptionsScanner Internationalization Usability

--- a/site/content/getting-started/index.md
+++ b/site/content/getting-started/index.md
@@ -59,7 +59,7 @@ ZAP provides functionality for a range of skill levels – from developers, to t
 
 Because ZAP is open-source, the source code can be examined to see exactly how the functionality is implemented. Anyone can volunteer to work on ZAP, fix bugs, add features, create pull requests to pull fixes into the project, and author add-ons to support specialized situations.
 
-As with most open source projects, donations are welcome to help with costs for the projects. You can find a donate button on the owasp.org page for ZAP at [https://www.owasp.org/index.php/ZAP](https://www.owasp.org/index.php/ZAP).
+As with most open source projects, donations are welcome to help with costs for the projects. You can find a donate button on the owasp.org page for ZAP at [https://owasp.org/www-project-zap/](https://owasp.org/www-project-zap/).
 
 ### Install and Configure ZAP
 ZAP has installers for Windows, Linux, and Mac OS/X. There are also Docker images available on the download site listed below.

--- a/site/data/studenthof.yaml
+++ b/site/data/studenthof.yaml
@@ -117,7 +117,7 @@
   title: SOAP scanning
   date: 2014 Summer
   links: >
-    <a href="https://zaproxy.blogspot.com/2014/09/albertos-gsoc-2014-project-for-zap-soap.html" rel="nofollow">Blog</a>
+    <a href="/blog/2014-09-03-alberto-s-gsoc-2014-project-for-zap-soap-scanner-add-on/" rel="nofollow">Blog</a>
 
 - name: Cosmin Stefan
   email: 

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -32,7 +32,7 @@
 
     <div class="flex ai-c">
       <span>
-      ZAP is an <a href="https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project">OWASP Flagship project</a><br>
+      ZAP is an <a href="https://owasp.org/www-project-zap/">OWASP Flagship project</a><br>
       © Copyright 2020 the ZAP Dev Team
       </span>
       <ul class="flex footer-social">


### PR DESCRIPTION
Link to new OWASP ZAP page.
Avoid redirects `crowdin.net` → `crowdin.com`.
Prevent link to `www.zap.com`.
Link to site blog post.