### PR TITLE
Tweak blog post author section

### DIFF
--- a/site/data/authors.yml
+++ b/site/data/authors.yml
@@ -1,25 +1,25 @@
 simon:
   name: Simon Bennetts
   picture: /img/authors/simon-bennetts_400x400.jpg
-  twitter: '@psiinon'
+  twitter: psiinon
   is_core: true
 
 ricardo:
   name: Ricardo 
   picture: 
-  twitter: '@thc202'
+  twitter: thc202
   is_core: true
 
 thorin:
   name: Rick Mitchell
   picture: /img/authors/rick-mitchell_400x400.jpg
-  twitter: '@kingthorin_rm'
+  twitter: kingthorin_rm
   is_core: true
 
 david:
   name: David Scrobonia
   picture: /img/authors/david-scrobonia_400x400.png
-  twitter: '@david_scrobonia'
+  twitter: david_scrobonia
   is_core: true
 
 jordan:
@@ -37,5 +37,5 @@ alberto:
 diogo:
   name: Diogo Silva
   picture:
-  twitter: '@Dimiresi'
+  twitter: Dimiresi
   is_core: false

--- a/site/layouts/post/single.html
+++ b/site/layouts/post/single.html
@@ -33,20 +33,21 @@
             {{ range $name := .Params.authors }}
             {{ $author := index $.Site.Data.authors $name }}
               <section class="post-author-single flex p-10">
-              {{ if $author }}
                 <div class="col-1-5">
+                  {{ if $author.picture }}
                   <img class="author-picture" src="{{ $author.picture }}" />
+                  {{ end }}
                 </div>
                 <div class="author-name col-4-5">
-                  {{ $author.name }}
-                  <a class="author-twitter" href="https://twitter.com/{{ $author.twitter }}">{{ $author.twitter }}</a>
+                  {{ if $author.name }}
+                    {{ $author.name }}
+                  {{ else }}
+                    {{ $name }}
+                  {{ end }}
+                  {{ if $author.twitter }}
+                  <a class="author-twitter" href="https://twitter.com/{{ $author.twitter }}">@{{ $author.twitter }}</a>
+                  {{ end }}
                 </div>
-              {{ else }}
-                <div class="col-1-5">
-                  <img class="author-picture" src="x" />
-                </div>
-                <div class="author-name col-4-5">{{ $name }}</div>
-              {{ end }}
               </section>
           {{ end }}
           </div>


### PR DESCRIPTION
Do not show the image if there's none (for author and single name).
Remove `@` from the Twitter handles in authors data, add it to the link
text to avoid the redirect to the URL without `@`.
Merge single name and author handling.