### PR TITLE
Update 'test' GitHub action to use checkout v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - run: sudo apt-get update && sudo apt-get install -y nginx
       


### PR DESCRIPTION
To hopefully address re-run failures such as:
https://github.com/zaproxy/zaproxy-website/runs/606957636?check_suite_focus=true

Ref: https://github.com/actions/checkout/issues/23#issuecomment-572688577

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>