### PR TITLE
add aria labels to input and link

### DIFF
--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <header class="site-header">
     <div class="wrapper flex jc-sb ai-c">
     <div class="flex">
-        <a href="/" class="logo">
+        <a href="/" aria-label="return to landing page" class="logo">
             <svg xmlns="http://www.w3.org/2000/svg" width="55px" viewBox="0 0 54.98 55"><defs><radialGradient id="a" cx="29.16" cy="29.18" r="25.82" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#4389ff"/><stop offset="1" stop-color="#00549e"/></radialGradient></defs><circle cx="29.16" cy="29.18" r="25.82" fill="url(#a)"/><path d="M2.17 10.82L22.67 2a.34.34 0 0 1 .42.12l11.08 15.74a.37.37 0 0 1-.18.57l-3 1a.37.37 0 0 0-.16.58l8.75 11a.37.37 0 0 1-.19.59l-3.79.93a.37.37 0 0 0-.2.59l12.92 16.32a.36.36 0 0 1-.44.55l-29-16.74a.37.37 0 0 1 .05-.66l3.5-1.39a.37.37 0 0 0 .07-.64l-11.78-8.5a.38.38 0 0 1 .07-.64l2.69-1.18a.37.37 0 0 0 .06-.64L2.1 11.46a.37.37 0 0 1 .07-.64z" fill="#fff"/><path d="M22.8 2a.35.35 0 0 1 .29.15l11.08 15.71a.37.37 0 0 1-.18.57l-3 1a.37.37 0 0 0-.16.58l8.75 11a.37.37 0 0 1-.19.59l-3.79.93a.37.37 0 0 0-.2.59l12.92 16.32a.37.37 0 0 1-.27.6.3.3 0 0 1-.17 0l-29-16.74a.37.37 0 0 1 .05-.66l3.5-1.39a.37.37 0 0 0 .07-.64l-11.78-8.5a.38.38 0 0 1 .07-.64l2.69-1.18a.37.37 0 0 0 .06-.64L2.1 11.46a.37.37 0 0 1 .07-.64L22.67 2a.31.31 0 0 1 .13 0m0-2a2.22 2.22 0 0 0-.91.19L1.4 9a2.32 2.32 0 0 0-.43 4l9.16 6.52-.14.06a2.34 2.34 0 0 0-.42 4L19 30.45l-.81.32a2.33 2.33 0 0 0-.3 4.17l29 16.74a2.23 2.23 0 0 0 1.15.31 2.32 2.32 0 0 0 1.8-3.76L38.48 33.82l1.41-.34A2.32 2.32 0 0 0 41.52 32a2.36 2.36 0 0 0-.38-2.2l-7.34-9.26.79-.26a2.29 2.29 0 0 0 1.48-1.46 2.36 2.36 0 0 0-.3-2.08L24.68 1a2.3 2.3 0 0 0-1.88-1z"/></svg>
         </a>
         <nav class="site-nav" role="navigation">
@@ -15,7 +15,7 @@
         <div class="hamburger-icon">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
         </div>
-        <input class="hamburger-click" type="checkbox" />
+        <input class="hamburger-click" aria-label="site menu" type="checkbox" />
         <ul id="primary-menu" class="flex">
           {{ $currentPage := . }}
           {{ range .Site.Menus.nav }}


### PR DESCRIPTION
**- Summary**

The accessibility of the site was lessened by the lack of labels on one input and one link. These are easy wins with no risk of affecting existing functionality.

**- Test plan**

run lighthouse audit in chrome browser.

_current site audit_
![current site](https://user-images.githubusercontent.com/5070516/82368746-d52d7580-9a0d-11ea-8daa-e1c832077b37.png)

_running locally after adding aria labels_
![after adding labels](https://user-images.githubusercontent.com/5070516/82368786-e37b9180-9a0d-11ea-93e0-0fb31a7ca359.png)


**- Description for the changelog**

Added aria labels to address a11y issues.

**- A picture of a cute animal (not mandatory but encouraged)**
