### PR TITLE
reorder layers in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,12 @@ COPY .babelrc \
     webpack.dev.js \
     webpack.prod.js /app/
 
-COPY site/ /app/site
-COPY src/ /app/src
-
 WORKDIR /app
 
 RUN npm install
+
+COPY site/ /app/site
+COPY src/ /app/src
+
 RUN npm run build
 CMD npm run preview


### PR DESCRIPTION
**- Summary**

The dependencies in the `npm install` layer are likely to change very infrequently,
whereas the code in the `/app` directories is likely to change more often.

So we can take advantage of docker layer caching to reuse the node_modules when
rebuilding after a code change to the frontend.

**- Test plan**

run the docker build steps as outlined in the README.

**- Description for the changelog**

Reorder layers in Dockerfile to optimize build times during local development.

**- A picture of a cute animal (not mandatory but encouraged)**
