### PR TITLE
Cookie Consent

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -30,6 +30,7 @@
   {{ $stylesheet := .Site.Data.webpack.main }}
   {{ with $stylesheet.css }}
     <link href="{{ relURL . }}" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css" />
   {{ end }}
 </head>
 <body>
@@ -42,6 +43,27 @@
   {{ $script := .Site.Data.webpack.main }}
   {{ with $script.js }}
     <script src="{{ relURL . }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js" data-cfasync="false"></script>
+    <script>
+    window.cookieconsent.initialise({
+      "palette": {
+        "popup": {
+          "background": "#edeff5",
+          "text": "#444444"
+        },
+        "button": {
+          "background": "#ffa400",
+          "text": "#fff6f7"
+        }
+      },
+      "theme": "classic",
+      "position": "bottom",
+      "type": "opt-in",
+      "content": {
+        "href": "https://www.zaproxy.com/cookies"
+      }
+    });
+    </script>
   {{ end }}
 </div>
 </body>


### PR DESCRIPTION
**Note**: This PR is still a WIP. Right now the buttons are not functional.

**- Summary**
This PR adds a banner for **cookie consent**. Right now the site uses google analytics, this will allow users to opt out/in to being tracked with GA.

**- Test plan**
I tried running `npm run test` but there are no tests that are run! :shrug: 

**- Description for the changelog**
> Adds cookie consent banner for managing Google Analytics.

![image](https://user-images.githubusercontent.com/5150944/83292759-831fe900-a19f-11ea-9af5-70d8e100669e.png)
