### PR TITLE
Add social media preview to homepage

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,0 +1,8 @@
+---
+headless: true
+addSocialPreview: true
+description: Welcome to ZAP!
+title: The ZAP Homepage
+images:
+- https://www.zaproxy.org/img/bolt-header.png
+---


### PR DESCRIPTION
**- Summary**

The place where Hugo expects the homepage front matter and params to live is at
`/content/_index.md`, and this file was missing, so this commit adds it.

documentation from hugo: https://gohugo.io/templates/homepage/
    
This was causing a lack of twitter and facebook previews for the homepage.

_current page without social media meta tags_
![no twitter or og meta tags](https://user-images.githubusercontent.com/5070516/83320974-478b2a80-a244-11ea-8a39-bbe42ad5a0e1.png)


**- Test plan**


Firing up the homepage on localhost should now show all the relevant social media preview meta tags.

![homepage with social media preview meta tags](https://user-images.githubusercontent.com/5070516/83320948-f7ac6380-a243-11ea-9212-afd32221835f.png)


**- Description for the changelog**

Add social media previews for the homepage

**- A picture of a cute animal (not mandatory but encouraged)**
