### PR TITLE
Add supporters page

### DIFF
--- a/site/content/get-involved.md
+++ b/site/content/get-involved.md
@@ -36,6 +36,10 @@ links:
     link: https://bugcrowd.com/owaspzap
     desc: for reporting any vulnerabilities 
 
+  - name: 'Supporters'
+    link: /supporters/
+    desc: Companies who have supported ZAP in a variety of ways 
+
   - name: 'Third Party Engagement'
     link: /third-party-engagement/
     desc: How Third Parties can use ZAP and engage with the ZAP Core Team 

--- a/site/content/supporters.md
+++ b/site/content/supporters.md
@@ -1,0 +1,59 @@
+---
+type: page
+title: Supporters
+layout: links
+header: Companies and organisations who have supported ZAP in a variety of ways
+links:
+  - name: 'Mozilla'
+    link: https://www.mozilla.org/
+    notes: Sponsored Simon for 8 years and $10,000 donation
+
+  - name: 'OWASP'
+    link: https://www.owasp.org/
+    notes: General support and an early significant donation
+
+  - name: 'Segment'
+    link: https://segment.com/
+    notes: Sponsored some of David's work on the HUD
+
+  - name: 'Salesforce'
+    link: https://www.salesforce.com/
+    notes: $9,000 in donations
+
+  - name: 'OWASP Denver'
+    link: https://owasp.org/www-chapter-denver/
+    notes: A $5,000 donation
+
+  - name: 'Google'
+    link: https://www.google.com/
+    notes: $4,500 donations via GSoC 
+
+  - name: 'Denim Group'
+    link: https://www.denimgroup.com/
+    notes: $3,000 in donations
+
+  - name: 'HiSolution AG'
+    link: https://www.hisolutions.com/
+    notes: $1,000 donation
+
+  - name: 'Faraday'
+    link: https://www.faradaysec.com/
+    notes: $900 donation
+
+  - name: 'Sage'
+    link: https://www.sage.co.uk/
+    notes: Sponsored some of Simon's initial work on ZAP
+
+  - name: 'Microsoft'
+    link: https://www.microsoft.com/
+
+  - name: 'DinoSec'
+    link: https://www.dinosec.com/
+
+  - name: 'Aspect Security'
+    link: http://www.aspectsecurity.com/
+
+  - name: 'Accenture Digital'
+    link: https://www.accenture.com/us-en/digital-index.aspx
+
+---

--- a/site/layouts/page/links.html
+++ b/site/layouts/page/links.html
@@ -21,7 +21,7 @@
               <div class="circle-arrow mr-20">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px"><g data-name="Layer 2"><circle cx="15" cy="15" r="15" fill="#4389ff"/><path fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M12.72 8.64L19.07 15l-6.35 6.36"/></g></svg></div>
               <div>
-                <p> <b><a href="{{ .link }}"> {{ .name }}</a></b> - {{ .desc }}</p>
+                <p> <b><a href="{{ .link }}"> {{ .name }}</a></b> {{ if .desc }} - {{ .desc }} {{ end }}</p>
               </div>
             </div>
           {{ end }}


### PR DESCRIPTION
Fixes #5

Its supposed to be roughly in order of level of support - the notes explain why the top ones are there, the lower ones I'm less sure about ;)

It could definitely be prettier, but getting all of the logos to be equivalent size could be painful :P
Any other suggestions?

I guess we could include the zapbot climbing the tower image on the right, I think thats what it was originally for...

Signed-off-by: Simon Bennetts <psiinon@gmail.com>

