### PR TITLE
add -I to api-scan

### DIFF
--- a/site/content/docs/docker/api-scan.md
+++ b/site/content/docs/docker/api-scan.md
@@ -38,6 +38,7 @@ Options:
     -P                specify listen port
     -D                delay in seconds to wait for passive scanning 
     -i                default rules not in the config file to INFO
+    -I                do not return failure on warning
     -l level          minimum level to show: PASS, IGNORE, INFO, WARN or FAIL, use with -s to hide example URLs
     -n context_file   context file which will be loaded prior to scanning the target
     -p progress_file  progress file which specifies issues that are being addressed

--- a/site/content/docs/docker/full-scan.md
+++ b/site/content/docs/docker/full-scan.md
@@ -35,6 +35,7 @@ Options:
     -P                specify listen port
     -D                delay in seconds to wait for passive scanning 
     -i                default rules not in the config file to INFO
+    -I                do not return failure on warning
     -j                use the Ajax spider in addition to the traditional one
     -l level          minimum level to show: PASS, IGNORE, INFO, WARN or FAIL, use with -s to hide example URLs
     -n context_file   context file which will be loaded prior to scanning the target


### PR DESCRIPTION
Signed-off-by: jammasterj89 <19202716+jammasterj89@users.noreply.github.com>
Simple documentation change:
Ensure API scan has -I flag in options, as it does exist in the script.
This is copied from /baseline-scan/ to ensure consistency.