### PR TITLE
Tweak Evangelists Link Check

### DIFF
--- a/.github/workflows/check-evangelists-links.yml
+++ b/.github/workflows/check-evangelists-links.yml
@@ -1,6 +1,7 @@
 on:
   schedule:
     - cron:  '0 2 1 * *'
+  workflow_dispatch:
 
 name: Evangelists Broken Link Check
 jobs:
@@ -21,4 +22,4 @@ jobs:
         run: wget https://www.zaproxy.org/evangelists/
       - name: Check Links
         # linkedin doesn't play nice, it's always status 999, likely due to robots.txt exclusion
-        run: link-checker ./index.html --external-only --http-status-ignore 301 302 --url-ignore .*linkedin.*
+        run: link-checker ./index.html --external-only --http-always-get --http-status-ignore 301 302 307 --url-ignore .*linkedin.*


### PR DESCRIPTION
- A reps.mozilla.org link was returning 307. Add 307 to the ignore status list.
- A medium link was returning 405. Add `http-always-get` switch as defaulting to `HEAD` is the normal behavior (verified with ZAP that this is indeed the culprit).
- Added web trigger.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>