### PR TITLE
Add 3rd party products and services page

### DIFF
--- a/site/content/get-involved.md
+++ b/site/content/get-involved.md
@@ -40,6 +40,10 @@ links:
     link: /supporters/
     desc: Companies who have supported ZAP in a variety of ways 
 
+  - name: 'Third Party Products and Services'
+    link: /third-party-services/
+    desc: Third Party products and services that use or integrate with ZAP 
+
   - name: 'Third Party Engagement'
     link: /third-party-engagement/
     desc: How Third Parties can use ZAP and engage with the ZAP Core Team 

--- a/site/content/third-party-services.md
+++ b/site/content/third-party-services.md
@@ -1,0 +1,10 @@
+---
+type: page
+title: Third Party Products and Services
+layout: thirdparty
+description: Third Party Products and Services which use or integrate with ZAP.
+warning: Note that these are not endorsed by either OWASP or the ZAP team.
+desc_services: Services that use ZAP.
+desc_integrations: Services and products that can import ZAP results.
+desc_other: Other services related to ZAP.
+---

--- a/site/data/thirdparty.yaml
+++ b/site/data/thirdparty.yaml
@@ -1,0 +1,55 @@
+---
+
+services:
+  - name: 'StackHawk'
+    link: https://www.stackhawk.com/
+    logo: /img/supporters/stackhawk.png
+    supporter: ZAP Platinum Supporter
+
+  - name: 'GitLab'
+    link: https://docs.gitlab.com/ee/user/application_security/dast/
+
+  - name: 'DeepFactor'
+    link: https://deepfactor.io/
+
+  - name: 'HostedScan'
+    link: https://hostedscan.com/
+
+  - name: 'Sken.ai'
+    link: https://www.sken.ai/
+
+  - name: 'PatrOwl'
+    link: https://patrowl.io/
+
+integrations:
+  - name: 'ThreadFix'
+    link: https://threadfix.it/
+    logo: /img/supporters/denimgroup.png
+    license: 'Commercial'
+    supporter: ZAP Silver Supporter
+
+  - name: 'Faraday'
+    link: https://www.faradaysec.com/
+    license: 'Open source community edition'
+    supporter: ZAP Bronze Supporter
+
+  - name: 'DefectDojo'
+    link: https://www.defectdojo.org/
+    license: 'Free, open source'
+ 
+  - name: 'Dradis'
+    link: https://dradisframework.com/ce/
+    license: 'Open source community edition'
+ 
+  - name: 'Sn1per'
+    link: https://github.com/1N3/Sn1per
+    license: 'Open source community edition'
+ 
+  - name: 'Edgescan'
+    link: https://www.edgescan.com/
+    license: 'Commercial'
+ 
+other:
+  - name: 'Pluralsight'
+    link: https://www.pluralsight.com/courses/owasp-zap-web-app-pentesting-getting-started
+    what: 'ZAP Getting Started Course'

--- a/site/layouts/page/thirdparty.html
+++ b/site/layouts/page/thirdparty.html
@@ -1,0 +1,57 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
+
+{{ define "main" }}
+{{ $section := .Site.GetPage "section" .Section }}
+<section class="bolt-header">
+    <div class="wrapper py-20">
+      <h1 class="text--white">{{ .Title }}</h1>
+  </div>
+</section>
+<section class="wrapper py-70" data-kind="{{ .Kind }}">
+  <article>
+
+<h5>{{ .Params.description }}</h5>
+<h5>{{ .Params.warning }}</h5>
+
+<h2>Services</h2>
+<div>{{ .Params.desc_services }}</div>
+
+<table>
+{{ range $service := $.Site.Data.thirdparty.services }}
+  <tr>
+  <td><a href="{{ $service.link }}">{{ if $service.logo }}<img src="{{ $service.logo }}" width="50%" height="50%"/>{{ else }}{{ $service.name }}{{ end }}</a></td>
+  <td><h5><a href="/supporters/">{{ $service.supporter }}</h5></a></td>
+  </tr>
+{{ end }}
+</table>
+<br/><br/>
+
+<h2>Integrations</h2>
+<div>{{ .Params.desc_integrations }}</div>
+<table>
+{{ range $integration := $.Site.Data.thirdparty.integrations }}
+  <tr>
+  <td><a href="{{ $integration.link }}">{{ if $integration.logo }}<img src="{{ $integration.logo }}" width="50%" height="50%"/>{{ else }}{{ $integration.name }}{{ end }}</a></td>
+  <td>{{ $integration.license }}</td>
+  <td><h5><a href="/supporters/">{{ $integration.supporter }}</h5></a></td>
+  </tr>
+{{ end }}
+</table>
+<br/><br/>
+
+<h2>Other</h2>
+<div>{{ .Params.desc_other }}</div>
+<table>
+{{ range $other := $.Site.Data.thirdparty.other }}
+  <tr>
+  <td><a href="{{ $other.link }}">{{ if $other.logo }}<img src="{{ $other.logo }}" width="50%" height="50%"/>{{ else }}{{ $other.name }}{{ end }}</a></td>
+  <td>{{ $other.what }}</td>
+  <td><h5><a href="/supporters/">{{ $other.supporter }}</h5></a></td>
+  </tr>
+{{ end }}
+</table>
+
+  </article>
+</section>
+{{ end }}
+


### PR DESCRIPTION
Priority is given to ZAP supporters.
Logos are displayed as per the supporters page.
Screenshot: 
![Screenshot_2020-08-27 OWASP ZAP – Third Party Products and Services](https://user-images.githubusercontent.com/1081115/91456144-37a2d700-e883-11ea-99e4-2f83e47238c8.png)
