### PR TITLE
Added courses and misc tweaks

### DIFF
--- a/site/content/third-party-services.md
+++ b/site/content/third-party-services.md
@@ -5,6 +5,6 @@ layout: thirdparty
 description: Third Party Products and Services which use or integrate with ZAP.
 warning: Note that these are not endorsed by either OWASP or the ZAP team.
 desc_services: Services that use ZAP.
-desc_integrations: Services and products that can import ZAP results.
-desc_other: Other services related to ZAP.
+desc_integrations: Products and services that can import ZAP results.
+desc_training: ZAP related training courses.
 ---

--- a/site/data/thirdparty.yaml
+++ b/site/data/thirdparty.yaml
@@ -4,22 +4,33 @@ services:
   - name: 'StackHawk'
     link: https://www.stackhawk.com/
     logo: /img/supporters/stackhawk.png
+    license: 'Commercial, free for open source projects'
     supporter: ZAP Platinum Supporter
+
+  - name: 'SecureCodeBox'
+    link: https://www.securecodebox.io/
+    license: 'Free, open source'
+    notes: OWASP Project
 
   - name: 'GitLab'
     link: https://docs.gitlab.com/ee/user/application_security/dast/
+    license: 'Commercial'
 
   - name: 'DeepFactor'
     link: https://deepfactor.io/
+    license: 'Commercial, free community edition'
 
   - name: 'HostedScan'
     link: https://hostedscan.com/
+    license: 'Commercial, free option'
 
   - name: 'Sken.ai'
     link: https://www.sken.ai/
+    license: 'Commercial, free option'
 
   - name: 'PatrOwl'
     link: https://patrowl.io/
+    license: 'Commercial, free for open source projects'
 
 integrations:
   - name: 'ThreadFix'
@@ -36,6 +47,7 @@ integrations:
   - name: 'DefectDojo'
     link: https://www.defectdojo.org/
     license: 'Free, open source'
+    notes: OWASP Project
  
   - name: 'Dradis'
     link: https://dradisframework.com/ce/
@@ -49,7 +61,27 @@ integrations:
     link: https://www.edgescan.com/
     license: 'Commercial'
  
-other:
+training:
+  - name: 'Coursera'
+    link: https://www.coursera.org/projects/web-application-security-testing-with-owsap-zap
+    what: 'Web Application Security Testing with OWASP ZAP'
+
+  - name: 'Cycubix'
+    link: https://cycubix.com/course/web-application-security-essentials/
+    what: 'Web Application Security Essentials'
+
+  - name: 'Cybrary'
+    link: https://www.cybrary.it/course/owasp-tutorial/
+    what: 'OWASP ZAP Tool'
+
+  - name: 'Eduonix'
+    link: https://www.eduonix.com/pentesting-with-owasp-zap-mastery-course
+    what: 'PenTesting with OWASP ZAP: mastery course'
+
   - name: 'Pluralsight'
     link: https://www.pluralsight.com/courses/owasp-zap-web-app-pentesting-getting-started
     what: 'ZAP Getting Started Course'
+
+  - name: 'Udemy'
+    link: https://www.udemy.com/course/owasp-zap-from-scratch/
+    what: 'OWASP ZAP From Scratch'

--- a/site/layouts/page/thirdparty.html
+++ b/site/layouts/page/thirdparty.html
@@ -16,11 +16,12 @@
 <h2>Services</h2>
 <div>{{ .Params.desc_services }}</div>
 
-<table>
+<table class="table table-fixed">
 {{ range $service := $.Site.Data.thirdparty.services }}
   <tr>
-  <td><a href="{{ $service.link }}">{{ if $service.logo }}<img src="{{ $service.logo }}" width="50%" height="50%"/>{{ else }}{{ $service.name }}{{ end }}</a></td>
-  <td><h5><a href="/supporters/">{{ $service.supporter }}</h5></a></td>
+  <td class="cell-35"><a href="{{ $service.link }}">{{ if $service.logo }}<img src="{{ $service.logo }}"/>{{ else }}{{ $service.name }}{{ end }}</a></td>
+  <td class="cell-35">{{ $service.license }}</td>
+  <td class="cell-30">{{ if $service.supporter }}<a href="/supporters/"><h5>{{ $service.supporter }}</h5></a>{{ end }}{{ if $service.notes }}{{ $service.notes }}{{ end }}</td>
   </tr>
 {{ end }}
 </table>
@@ -28,25 +29,25 @@
 
 <h2>Integrations</h2>
 <div>{{ .Params.desc_integrations }}</div>
-<table>
+<table class="table table-fixed">
 {{ range $integration := $.Site.Data.thirdparty.integrations }}
   <tr>
-  <td><a href="{{ $integration.link }}">{{ if $integration.logo }}<img src="{{ $integration.logo }}" width="50%" height="50%"/>{{ else }}{{ $integration.name }}{{ end }}</a></td>
-  <td>{{ $integration.license }}</td>
-  <td><h5><a href="/supporters/">{{ $integration.supporter }}</h5></a></td>
+  <td class="cell-35"><a href="{{ $integration.link }}">{{ if $integration.logo }}<img src="{{ $integration.logo }}"/>{{ else }}{{ $integration.name }}{{ end }}</a></td>
+  <td class="cell-35">{{ $integration.license }}</td>
+  <td class="cell-30">{{ if $integration.supporter }}<a href="/supporters/"><h5>{{ $integration.supporter }}</h5></a>{{ end }}{{ if $integration.notes }}{{ $integration.notes }}{{ end }}</td>
   </tr>
 {{ end }}
 </table>
 <br/><br/>
 
-<h2>Other</h2>
-<div>{{ .Params.desc_other }}</div>
-<table>
-{{ range $other := $.Site.Data.thirdparty.other }}
+<h2>Training</h2>
+<div>{{ .Params.desc_training }}</div>
+<table class="table table-fixed">
+{{ range $training := $.Site.Data.thirdparty.training }}
   <tr>
-  <td><a href="{{ $other.link }}">{{ if $other.logo }}<img src="{{ $other.logo }}" width="50%" height="50%"/>{{ else }}{{ $other.name }}{{ end }}</a></td>
-  <td>{{ $other.what }}</td>
-  <td><h5><a href="/supporters/">{{ $other.supporter }}</h5></a></td>
+  <td class="cell-35">{{ if $training.logo }}<img src="{{ $training.logo }}" width="50%" height="50%"/>{{ else }}{{ $training.name }}{{ end }}</td>
+  <td class="cell-35"><a href="{{ $training.link }}">{{ $training.what }}</a></td>
+  <td class="cell-30"><a href="/supporters/"><h5>{{ $training.supporter }}</h5></a></td>
   </tr>
 {{ end }}
 </table>

--- a/src/css/_page.scss
+++ b/src/css/_page.scss
@@ -36,6 +36,13 @@ table {
 
 }
 
+.table-fixed {
+  table-layout: fixed;
+}
+
+table.table-fixed h5 { 
+  margin-bottom: 0px;
+}
 
 th {
   border-bottom: solid 3px var(--grey-light);
@@ -46,6 +53,22 @@ td {
   padding: 4px;
   border-bottom: solid 1px var(--grey-light);
 }
+
+.cell-30 {
+  width: 30%;
+  vertical-align: middle;
+}
+
+.cell-35 {
+  width: 35%;
+  vertical-align: middle;
+}
+
+.cell-70 {
+  width: 70%;
+  vertical-align: middle;
+}
+
 .wrapper {
   max-width: 1300px;
   margin: 0 auto;


### PR DESCRIPTION
Changed the 'Other' section to 'Training' and added a lolad of courses I found online.
Linked to the courses from the course name, eg in case any add more ZAP courses.
Lined up the columns and aligned the ZAP Supporter links.
Flagged DefectDojo as an OWASP Project.

Scrrenshot:
![Screenshot_2020-08-28 OWASP ZAP – Third Party Products and Services](https://user-images.githubusercontent.com/1081115/91547761-a97f2d00-e924-11ea-8f35-b36f00a2f1f6.png)


Signed-off-by: Simon Bennetts <psiinon@gmail.com>
