### PR TITLE
Related to #166  ... improve layout for alerts

### DIFF
--- a/site/layouts/alert/single.html
+++ b/site/layouts/alert/single.html
@@ -6,17 +6,89 @@
 </section>
 {{ $section := .Site.GetPage "section" .Section }}
 <div class="wrapper py-20" data-kind="{{ .Kind }}">
-    <div class="breadcrumbs">
+    <header class="breadcrumbs">
         <a href="/docs/">Docs</a> &gt;
         <a href="/docs/alerts/">Alerts</a>
-    </div>
-    <div class="flex">
-      <article class="pr-30 content single-post">
-          <main class="post-content">
-            {{ .Content }}
-          </main>
-      </article>
-    </div>
+    </header>
+    <main class="post-content flex pt-10 on-sm-stack">
+      <section class="col-1-3 mr-30 mb-30">
+        <table class="bordered">
+          <thead>
+            <tr>
+              <th colspan="2">
+                Details
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <strong>Alertid</strong>
+              </td>
+              <td>{{ .Params.alertid }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>Alert Type</strong>
+              </td>
+              <td>{{ .Params.alert_type }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>Status</strong>
+              </td>
+              <td>{{ .Params.status }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>
+                  Risk
+                </td>
+              <td>{{ .Params.risk }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>CWE</strong>
+              </td>
+              <td>
+                <a href="https://cwe.mitre.org/data/definitions/{{ .Params.cwe }}.html">
+                  {{ .Params.cwe }}
+                </a>
+              </td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>WASC</strong>
+              </td>
+              <td>{{ .Params.wasc }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+      <section class="col-2-3">
+        <div data-attr="summary">
+          <h3 class="mb-10">Summary</h3>
+          {{ .Content }}
+        </div>
+        <div data-attr="solution" class="mb-20">
+          <h3 class="mb-10">Solution</h3>
+          {{ .Params.solution }}
+        </div>
+        <h3 class="mb-10">References</h3>
+        <ul data-attr="references">
+        {{ range .Params.references }}
+          <li>
+            <a href="{{ . }}">{{ . }}</a>
+          </li>
+        {{ end }}
+        </ul>
+        <h4 class="mb-10">Code</h4>
+          <a href='{{ .Params.code  }}'>
+            {{ index (split .Params.code "main/java/") 1 }}
+          </a>
+      </section>
+  </main>
 </div>
 {{ end }}
 

--- a/src/css/_page.scss
+++ b/src/css/_page.scss
@@ -34,6 +34,13 @@ table {
   width: 100%;
   border-collapse: collapse;
 
+  &.bordered {
+    border: solid 2px #eee;
+
+    td, th {
+      padding:4px 8px;
+    }
+  }
 }
 
 .table-fixed {
@@ -46,11 +53,12 @@ table.table-fixed h5 {
 
 th {
   border-bottom: solid 3px var(--grey-light);
-  padding: 4px;
+  padding: 4px 8px;
+  background:  var(--grey-light);
 }
 
 td {
-  padding: 4px;
+  padding: 4px 8px;
   border-bottom: solid 1px var(--grey-light);
 }
 

--- a/src/css/_spacing.scss
+++ b/src/css/_spacing.scss
@@ -1,5 +1,5 @@
 // Generate spacing for each size
-@each $size in 10 20 30 40 70  {
+@each $size in 0 10 20 30 40 70  {
   .p-#{$size} {
     padding: #{$size}px;
   }


### PR DESCRIPTION
Created a new layout for a single alert, which will have a format following this new structure.

```yaml
---
title: "Directory Browsing"
name: Directory Browsing
alertid: 0
alert_type: "Active Scan Rule"
alertcount: 1
status: release
type: alert
alert_type: Active Scan Rule
risk: Medium
solution: |
    Disable directory browsing.  If this is required, make sure the listed files does not induce risks.
references:
    - http://httpd.apache.org/docs/mod/core.html#options
    - http://alamo.satlug.org/pipermail/satlug/2002-February/000053.html
cwe: 548
wasc: 48
code:  https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
date: 2020-08-14 11:48:43.628Z
lastmod: 2020-08-14 11:48:43.628Z
---
<!-- Summary lives down here -->
It is possible to view the directory listing.  Directory listing may reveal hidden scripts, include files, backup source files, etc. which can be accessed to read sensitive information.
```


<img width="1228" alt="Screen Shot 2020-09-05 at 9 33 16 PM" src="https://user-images.githubusercontent.com/465024/92318337-b0124200-efbf-11ea-87f8-bdf89d12a88f.png">
