### PR TITLE
New 'Videos' page

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -24,8 +24,8 @@ menu:
       URL:  "/blog/"
       weight:  2
 
-    - name:  "ZAP in Ten"
-      URL: /zap-in-ten/
+    - name:  "Videos"
+      URL: /videos/
       weight:  3
 
     - name:  Documentation
@@ -50,8 +50,8 @@ menu:
       URL:  "/blog/"
       weight:  2
 
-    - name:  "ZAP in Ten"
-      URL:  /zap-in-ten/
+    - name:  "Videos"
+      URL:  /videos/
       weight:  3
 
     - name:  "Get Involved"

--- a/site/content/videos.md
+++ b/site/content/videos.md
@@ -1,0 +1,8 @@
+---
+type: page
+title: Videos
+layout: zap-in-ten
+uuid: RyTy22GZV6UccW41UCghC8
+---
+### ZAP in Ten: A series of short videos about different ZAP features
+#### Watch the first one below or see the full series [here](https://www.alldaydevops.com/zap-in-ten)


### PR DESCRIPTION
Partly because I'm concerned people might not realise 'ZAP in Ten' means
videos, and also so that we can use the page for other videos (some of
which might be coming soon;)

I've kept the ZAP in Ten page as people might have bookmarked it and we
might end up just linking to it from this page in the future.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
