### PR TITLE
Update ZAP scan actions

### DIFF
--- a/.github/workflows/zap-full-scan.yml
+++ b/.github/workflows/zap-full-scan.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.1.0
+        uses: zaproxy/action-full-scan@v0.2.0
         with:
           target: 'https://www.zaproxy.org/'
           # rules_file_name: '.github/workflows/rules.tsv'

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-baseline@v0.3.0
+        uses: zaproxy/action-baseline@v0.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target: 'https://www.zaproxy.org/'


### PR DESCRIPTION
Use latest versions to not fail the builds (enabled by default).