### PR TITLE
Revamp alert pages

### DIFF
--- a/site/content/docs/alerts/0.md
+++ b/site/content/docs/alerts/0.md
@@ -1,39 +1,20 @@
 ---
 title: "Directory Browsing"
 alertid: 0
+alertindex: 0
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Disable directory browsing.  If this is required, make sure the listed files does not induce risks."
+references:
+   - http://httpd.apache.org/docs/mod/core.html#options
+   - http://alamo.satlug.org/pipermail/satlug/2002-February/000053.html
+cwe: 548
+wasc: 48
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Directory Browsing
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 It is possible to view the directory listing.  Directory listing may reveal hidden scripts, include files, backup source files, etc. which can be accessed to read sensitive information.
-
-### Solution
-
-Disable directory browsing.  If this is required, make sure the listed files does not induce risks.
-
-### References
-
-* http://httpd.apache.org/docs/mod/core.html#options
-* http://alamo.satlug.org/pipermail/satlug/2002-February/000053.html
-* 
-
-### CWE: [548](https://cwe.mitre.org/data/definitions/548.html)
-
-### WASC:  48
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10003.md
+++ b/site/content/docs/alerts/10003.md
@@ -1,31 +1,16 @@
 ---
 title: "Vulnerable JS Library"
 alertid: 10003
+alertindex: 1000300
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-10-28 17:44:59.777Z
-lastmod: 2020-10-28 17:44:59.777Z
+risk: Medium
+solution: "Please upgrade to the latest version of ExampleLibrary."
+cwe: 829
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Vulnerable JS Library
-
-### Type: Passive Scan Rule
-
-### Risk: Medium
-
-### Description
-
 The identified library ExampleLibrary, version x.y.z is vulnerable.
-
-### Solution
-
-Please upgrade to the latest version of ExampleLibrary.
-
-### CWE: [829](https://cwe.mitre.org/data/definitions/829.html)
-
-### Code
-
- * [org/zaproxy/addon/retire/RetireScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java)
-
-###### Last updated: 2020-10-28 17:44:59.777Z

--- a/site/content/docs/alerts/10009.md
+++ b/site/content/docs/alerts/10009.md
@@ -1,34 +1,18 @@
 ---
 title: "In Page Banner Information Leak"
 alertid: 10009
+alertindex: 1000900
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Configure the server to prevent such information leaks. For example:
+Under Tomcat this is done via the 'server' directive and implementation of custom error pages.
+Under Apache this is done via the 'ServerSignature' and 'ServerTokens' directives."
+references:
+   - https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: In Page Banner Information Leak
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The server returned a version banner string in the response content. Such information leaks may allow attackers to further target specific issues impacting the product and version in use.
-
-### Solution
-
-Configure the server to prevent such information leaks. For example:
-Under Tomcat this is done via the "server" directive and implementation of custom error pages.
-Under Apache this is done via the "ServerSignature" and "ServerTokens" directives.
-
-### References
-
-* https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10010.md
+++ b/site/content/docs/alerts/10010.md
@@ -1,32 +1,19 @@
 ---
 title: "Cookie No HttpOnly Flag"
 alertid: 10010
+alertindex: 1001000
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Low
+solution: "Ensure that the HttpOnly flag is set for all cookies."
+references:
+   - https://owasp.org/www-community/HttpOnly
+cwe: 16
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cookie No HttpOnly Flag
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-
-### Solution
-
-Ensure that the HttpOnly flag is set for all cookies.
-
-### References
-
-* https://owasp.org/www-community/HttpOnly
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10011.md
+++ b/site/content/docs/alerts/10011.md
@@ -1,32 +1,19 @@
 ---
 title: "Cookie Without Secure Flag"
 alertid: 10011
+alertindex: 1001100
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Low
+solution: "Whenever a cookie contains sensitive information or is a session token, then it should always be passed using an encrypted channel. Ensure that the secure flag is set for cookies containing such sensitive information."
+references:
+   - https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.html
+cwe: 614
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cookie Without Secure Flag
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 A cookie has been set without the secure flag, which means that the cookie can be accessed via unencrypted connections.
-
-### Solution
-
-Whenever a cookie contains sensitive information or is a session token, then it should always be passed using an encrypted channel. Ensure that the secure flag is set for cookies containing such sensitive information.
-
-### References
-
-* https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.html
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10015.md
+++ b/site/content/docs/alerts/10015.md
@@ -1,32 +1,16 @@
 ---
 title: "Incomplete or No Cache-control and Pragma HTTP Header Set"
 alertid: 10015
+alertindex: 1001500
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#web-content-caching
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Incomplete or No Cache-control and Pragma HTTP Header Set
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.
-
-### Solution
-
-Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#web-content-caching
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10016.md
+++ b/site/content/docs/alerts/10016.md
@@ -1,33 +1,15 @@
 ---
 title: "Web Browser XSS Protection Not Enabled"
+name: "Web Browser XSS Protection Not Enabled"
 alertid: 10016
+alertindex: 1001600
 alerttype: "Passive Scan Rule"
-status: release
+status: deprecated
 type: alert
-date: 2020-04-30 09:48:11.442Z
-lastmod: 2020-04-30 09:48:11.442Z
+date: 2020-10-30 12:12:42.788Z
+lastmod: 2020-10-30 12:12:42.788Z
 ---
-## Deprecated: 2020-02-11
-No longer widely supported by browsers.
-
-### Type: Passive Scan
-
-### Description
 Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
 
-### Solution
-
-Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-
-### References
-
-* https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-* https://www.veracode.com/blog/2014/03/guidelines-for-setting-security-headers/
-
-
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/HeaderXssProtectionScanner.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeaderXssProtectionScanner.java)
-
-###### Last updated: 2020-04-30 09:48:11.442Z
+## Deprecated: 2020-02-11
+No longer widely supported by browsers.

--- a/site/content/docs/alerts/10017.md
+++ b/site/content/docs/alerts/10017.md
@@ -1,28 +1,14 @@
 ---
 title: "Cross-Domain JavaScript Source File Inclusion"
 alertid: 10017
+alertindex: 1001700
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure JavaScript source files are loaded from only trusted sources, and the sources can't be controlled by end users of the application."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cross-Domain JavaScript Source File Inclusion
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The page includes one or more script files from a third-party domain.
-
-### Solution
-
-Ensure JavaScript source files are loaded from only trusted sources, and the sources can't be controlled by end users of the application.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10019.md
+++ b/site/content/docs/alerts/10019.md
@@ -1,32 +1,16 @@
 ---
 title: "Content-Type Header Missing"
 alertid: 10019
+alertindex: 1001900
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure each page is setting the specific and appropriate content-type value for the content being delivered."
+references:
+   - http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Content-Type Header Missing
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The Content-Type header was either missing or empty.
-
-### Solution
-
-Ensure each page is setting the specific and appropriate content-type value for the content being delivered.
-
-### References
-
-* http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10020-1.md
+++ b/site/content/docs/alerts/10020-1.md
@@ -1,0 +1,19 @@
+---
+title: "X-Frame-Options Header Not Set"
+alertid: 10020-1
+alertindex: 1002001
+alerttype: "Passive Scan Rule"
+alertcount: 4
+status: release
+type: alert
+risk: Medium
+solution: "Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers)."
+references:
+   - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+cwe: 16
+wasc: 15
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.

--- a/site/content/docs/alerts/10020-2.md
+++ b/site/content/docs/alerts/10020-2.md
@@ -1,0 +1,19 @@
+---
+title: "Multiple X-Frame-Options Header Entries"
+alertid: 10020-2
+alertindex: 1002002
+alerttype: "Passive Scan Rule"
+alertcount: 4
+status: release
+type: alert
+risk: Medium
+solution: "Ensure only a single X-Frame-Options header is present in the response."
+references:
+   - https://tools.ietf.org/html/rfc7034
+cwe: 16
+wasc: 15
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+X-Frame-Options (XFO) headers were found, a response with multiple XFO header entries may not be predictably treated by all user-agents.

--- a/site/content/docs/alerts/10020-3.md
+++ b/site/content/docs/alerts/10020-3.md
@@ -1,0 +1,19 @@
+---
+title: "X-Frame-Options Defined via META (Non-compliant with Spec)"
+alertid: 10020-3
+alertindex: 1002003
+alerttype: "Passive Scan Rule"
+alertcount: 4
+status: release
+type: alert
+risk: Medium
+solution: "Ensure X-Frame-Options is set via a response header field."
+references:
+   - https://tools.ietf.org/html/rfc7034#section-4
+cwe: 16
+wasc: 15
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+An X-Frame-Options (XFO) META tag was found, defining XFO via a META tag is explicitly not supported by the spec (RFC 7034).

--- a/site/content/docs/alerts/10020-4.md
+++ b/site/content/docs/alerts/10020-4.md
@@ -1,0 +1,19 @@
+---
+title: "X-Frame-Options Setting Malformed"
+alertid: 10020-4
+alertindex: 1002004
+alerttype: "Passive Scan Rule"
+alertcount: 4
+status: release
+type: alert
+risk: Medium
+solution: "Ensure a valid setting is used on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers)."
+references:
+   - https://tools.ietf.org/html/rfc7034#section-2.1
+cwe: 16
+wasc: 15
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+An X-Frame-Options header was present in the response but the value was not correctly set.

--- a/site/content/docs/alerts/10020.md
+++ b/site/content/docs/alerts/10020.md
@@ -1,97 +1,24 @@
 ---
 title: "X-Frame-Options Header"
 alertid: 10020
+alertindex: 1002000
 alerttype: "Passive Scan Rule"
-alertcount: 4
 status: release
-type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+type: alertset
+alerts:
+   10020-1:
+      alertid: 10020-1
+      name: X-Frame-Options Header Not Set
+   10020-2:
+      alertid: 10020-2
+      name: Multiple X-Frame-Options Header Entries
+   10020-3:
+      alertid: 10020-3
+      name: X-Frame-Options Defined via META (Non-compliant with Spec)
+   10020-4:
+      alertid: 10020-4
+      name: X-Frame-Options Setting Malformed
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: X-Frame-Options Header Not Set
-
-### Type: Passive Scan Rule
-
-### Risk: Medium
-
-### Description
-
-X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.
-
-### Solution
-
-Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).
-
-### References
-
-* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-
-### CWE: [16](https://cwe.mitre.org/data/definitions/16.html)
-
-### WASC:  15
-
-## Name: Multiple X-Frame-Options Header Entries
-
-### Risk: Medium
-
-### Description
-
-X-Frame-Options (XFO) headers were found, a response with multiple XFO header entries may not be predictably treated by all user-agents.
-
-### Solution
-
-Ensure only a single X-Frame-Options header is present in the response.
-
-### References
-
-* https://tools.ietf.org/html/rfc7034
-
-### CWE: [16](https://cwe.mitre.org/data/definitions/16.html)
-
-### WASC:  15
-
-## Name: X-Frame-Options Defined via META (Non-compliant with Spec)
-
-### Risk: Medium
-
-### Description
-
-An X-Frame-Options (XFO) META tag was found, defining XFO via a META tag is explicitly not supported by the spec (RFC 7034).
-
-### Solution
-
-Ensure X-Frame-Options is set via a response header field.
-
-### References
-
-* https://tools.ietf.org/html/rfc7034#section-4
-
-### CWE: [16](https://cwe.mitre.org/data/definitions/16.html)
-
-### WASC:  15
-
-## Name: X-Frame-Options Setting Malformed
-
-### Risk: Medium
-
-### Description
-
-An X-Frame-Options header was present in the response but the value was not correctly set.
-
-### Solution
-
-Ensure a valid setting is used on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).
-
-### References
-
-* https://tools.ietf.org/html/rfc7034#section-2.1
-
-### CWE: [16](https://cwe.mitre.org/data/definitions/16.html)
-
-### WASC:  15
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10021.md
+++ b/site/content/docs/alerts/10021.md
@@ -1,34 +1,18 @@
 ---
 title: "X-Content-Type-Options Header Missing"
 alertid: 10021
+alertindex: 1002100
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.
+If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing."
+references:
+   - http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
+   - https://owasp.org/www-community/Security_Headers
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: X-Content-Type-Options Header Missing
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.
-
-### Solution
-
-Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.
-If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.
-
-### References
-
-* http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-* https://owasp.org/www-community/Security_Headers
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10023.md
+++ b/site/content/docs/alerts/10023.md
@@ -1,28 +1,14 @@
 ---
 title: "Information Disclosure - Debug Error Messages"
 alertid: 10023
+alertindex: 1002300
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Disable debugging messages before pushing to production."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Information Disclosure - Debug Error Messages
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The response appeared to contain common error messages returned by platforms such as ASP.NET, and Web-servers such as IIS and Apache. You can configure the list of common debug messages.
-
-### Solution
-
-Disable debugging messages before pushing to production.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10024.md
+++ b/site/content/docs/alerts/10024.md
@@ -1,28 +1,14 @@
 ---
 title: "Information Disclosure - Sensitive Information in URL"
 alertid: 10024
+alertindex: 1002400
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Do not pass sensitive information in URIs."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Information Disclosure - Sensitive Information in URL
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The request appeared to contain sensitive information leaked in the URL. This can violate PCI and most organizational compliance policies. You can configure the list of strings for this check to add or remove values specific to your environment.
-
-### Solution
-
-Do not pass sensitive information in URIs.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10025.md
+++ b/site/content/docs/alerts/10025.md
@@ -1,28 +1,14 @@
 ---
 title: "Information Disclosure - Sensitive Information in HTTP Referrer Header"
 alertid: 10025
+alertindex: 1002500
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Do not pass sensitive information in URIs."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Information Disclosure - Sensitive Information in HTTP Referrer Header
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The HTTP header may have leaked a potentially sensitive parameter to another domain. This can violate PCI and most organizational compliance policies. You can configure the list of strings for this check to add or remove values specific to your environment.
-
-### Solution
-
-Do not pass sensitive information in URIs.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10026.md
+++ b/site/content/docs/alerts/10026.md
@@ -1,32 +1,16 @@
 ---
 title: "HTTP Parameter Override"
 alertid: 10026
+alertindex: 1002600
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "All forms must specify the action URL."
+references:
+   - http://download.oracle.com/javaee-archive/servlet-spec.java.net/jsr340-experts/att-0317/OnParameterPollutionAttacks.pdf
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: HTTP Parameter Override
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Unspecified form action: HTTP parameter override attack potentially possible. This is a known problem with Java Servlets but other platforms may also be vulnerable.
-
-### Solution
-
-All forms must specify the action URL.
-
-### References
-
-* http://download.oracle.com/javaee-archive/servlet-spec.java.net/jsr340-experts/att-0317/OnParameterPollutionAttacks.pdf
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10027.md
+++ b/site/content/docs/alerts/10027.md
@@ -1,28 +1,14 @@
 ---
 title: "Information Disclosure - Suspicious Comments"
 alertid: 10027
+alertindex: 1002700
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Remove all comments that return information that may help an attacker and fix any underlying problems they refer to."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Information Disclosure - Suspicious Comments
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The response appears to contain suspicious comments which may help an attacker. Note: Matches made within script blocks or files are against the entire content not only comments.
-
-### Solution
-
-Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10028.md
+++ b/site/content/docs/alerts/10028.md
@@ -1,35 +1,19 @@
 ---
 title: "Open Redirect"
 alertid: 10028
+alertindex: 1002800
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "To avoid the open redirect vulnerability, parameters of the application script/program must be validated before sending 302 HTTP code (redirect) to the client browser. Implement safe redirect functionality that only redirects to relative URI's, or a list of trusted domains"
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
+   - https://cwe.mitre.org/data/definitions/601.html
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Open Redirect
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Open redirects are one of the OWASP 2010 Top Ten vulnerabilities. This check looks at user-supplied input in query string parameters and POST data to identify where open redirects might be possible. Open redirects occur when an application allows user-supplied input (e.g. http://nottrusted.com) to control an offsite redirect. This is generally a pretty accurate way to find where 301 or 302 redirects could be exploited by spammers or phishing attacks.
 
 For example an attacker could supply a user with the following link: http://example.com/example.php?url=http://malicious.example.com.
-
-### Solution
-
-To avoid the open redirect vulnerability, parameters of the application script/program must be validated before sending 302 HTTP code (redirect) to the client browser. Implement safe redirect functionality that only redirects to relative URI's, or a list of trusted domains
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
-* https://cwe.mitre.org/data/definitions/601.html
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10029.md
+++ b/site/content/docs/alerts/10029.md
@@ -1,32 +1,16 @@
 ---
 title: "Cookie Poisoning"
 alertid: 10029
+alertindex: 1002900
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Do not allow user input to control cookie names and values. If some query string parameters must be set in cookie values, be sure to filter out semicolon's that can serve as name/value pair delimiters."
+references:
+   - http://websecuritytool.codeplex.com/wikipage?title=Checks#user-controlled-cookie
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cookie Poisoning
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 This check looks at user-supplied input in query string parameters and POST data to identify where cookie parameters might be controlled. This is called a cookie poisoning attack, and becomes exploitable when an attacker can manipulate the cookie in various ways. In some cases this will not be exploitable, however, allowing URL parameters to set cookie values is generally considered a bug.
-
-### Solution
-
-Do not allow user input to control cookie names and values. If some query string parameters must be set in cookie values, be sure to filter out semicolon's that can serve as name/value pair delimiters.
-
-### References
-
-* http://websecuritytool.codeplex.com/wikipage?title=Checks#user-controlled-cookie
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10030.md
+++ b/site/content/docs/alerts/10030.md
@@ -1,28 +1,14 @@
 ---
 title: "User Controllable Charset"
 alertid: 10030
+alertindex: 1003000
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Force UTF-8 in all charset declarations. If user-input is required to decide a charset declaration, ensure that only an allowed list is used."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: User Controllable Charset
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 This check looks at user-supplied input in query string parameters and POST data to identify where Content-Type or meta tag charset declarations might be user-controlled. Such charset declarations should always be declared by the application. If an attacker can control the response charset, they could manipulate the HTML to perform XSS or other attacks. For example, an attacker controlling the <meta> element charset value is able to declare UTF-7 and is also able to include enough user-controlled payload early in the HTML document to have it interpreted as UTF-7. By encoding their payload with UTF-7 the attacker is able to bypass any server-side XSS protections and embed script in the page.
-
-### Solution
-
-Force UTF-8 in all charset declarations. If user-input is required to decide a charset declaration, ensure that only an allowed list is used.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10031.md
+++ b/site/content/docs/alerts/10031.md
@@ -1,32 +1,16 @@
 ---
 title: "User Controllable HTML Element Attribute (Potential XSS)"
 alertid: 10031
+alertindex: 1003100
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Validate all input and sanitize output it before writing to any HTML attributes."
+references:
+   - http://websecuritytool.codeplex.com/wikipage?title=Checks#user-controlled-html-attribute
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: User Controllable HTML Element Attribute (Potential XSS)
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.
-
-### Solution
-
-Validate all input and sanitize output it before writing to any HTML attributes.
-
-### References
-
-* http://websecuritytool.codeplex.com/wikipage?title=Checks#user-controlled-html-attribute
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10032-1.md
+++ b/site/content/docs/alerts/10032-1.md
@@ -1,0 +1,17 @@
+---
+title: "Potential IP Addresses Found in the Viewstate"
+alertid: 10032-1
+alertindex: 1003201
+alerttype: "Passive Scan Rule"
+alertcount: 6
+status: release
+type: alert
+risk: Medium
+solution: "Verify the provided information isn't confidential."
+cwe: 16
+wasc: 14
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+The following potential IP addresses were found being serialized in the viewstate field:

--- a/site/content/docs/alerts/10032-2.md
+++ b/site/content/docs/alerts/10032-2.md
@@ -1,0 +1,17 @@
+---
+title: "Emails Found in the Viewstate"
+alertid: 10032-2
+alertindex: 1003202
+alerttype: "Passive Scan Rule"
+alertcount: 6
+status: release
+type: alert
+risk: Medium
+solution: "Verify the provided information isn't confidential."
+cwe: 16
+wasc: 14
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+The following emails were found being serialized in the viewstate field:

--- a/site/content/docs/alerts/10032-3.md
+++ b/site/content/docs/alerts/10032-3.md
@@ -1,0 +1,20 @@
+---
+title: "Old Asp.Net Version in Use"
+alertid: 10032-3
+alertindex: 1003203
+alerttype: "Passive Scan Rule"
+alertcount: 6
+status: release
+type: alert
+risk: Low
+solution: "Ensure the engaged framework is still supported by Microsoft."
+cwe: 16
+wasc: 14
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+*** EXPERIMENTAL ***
+This website uses ASP.NET version 1.0 or 1.1.
+
+

--- a/site/content/docs/alerts/10032-4.md
+++ b/site/content/docs/alerts/10032-4.md
@@ -1,0 +1,22 @@
+---
+title: "Viewstate without MAC Signature (Unsure)"
+alertid: 10032-4
+alertindex: 1003204
+alerttype: "Passive Scan Rule"
+alertcount: 6
+status: release
+type: alert
+risk: High
+solution: "Ensure the MAC is set for all pages on this website."
+references:
+   - http://msdn.microsoft.com/en-us/library/ff649308.aspx
+cwe: 642
+wasc: 14
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+*** EXPERIMENTAL ***
+This website uses ASP.NET's Viewstate but maybe without any MAC.
+
+

--- a/site/content/docs/alerts/10032-5.md
+++ b/site/content/docs/alerts/10032-5.md
@@ -1,0 +1,22 @@
+---
+title: "Viewstate without MAC Signature (Sure)"
+alertid: 10032-5
+alertindex: 1003205
+alerttype: "Passive Scan Rule"
+alertcount: 6
+status: release
+type: alert
+risk: High
+solution: "Ensure the MAC is set for all pages on this website."
+references:
+   - http://msdn.microsoft.com/en-us/library/ff649308.aspx
+cwe: 642
+wasc: 14
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+*** EXPERIMENTAL ***
+This website uses ASP.NET's Viewstate but without any MAC.
+
+

--- a/site/content/docs/alerts/10032-6.md
+++ b/site/content/docs/alerts/10032-6.md
@@ -1,0 +1,19 @@
+---
+title: "Split Viewstate in Use"
+alertid: 10032-6
+alertindex: 1003206
+alerttype: "Passive Scan Rule"
+alertcount: 6
+status: release
+type: alert
+risk: Informational
+solution: "None - the guys running the server may have tuned the configuration as this isn't the default setting."
+cwe: 16
+wasc: 14
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+*** EXPERIMENTAL ***
+This website uses ASP.NET's Viewstate and its value is split into several chunks.
+

--- a/site/content/docs/alerts/10032.md
+++ b/site/content/docs/alerts/10032.md
@@ -1,132 +1,30 @@
 ---
 title: "Viewstate"
 alertid: 10032
+alertindex: 1003200
 alerttype: "Passive Scan Rule"
-alertcount: 6
 status: release
-type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+type: alertset
+alerts:
+   10032-1:
+      alertid: 10032-1
+      name: Potential IP Addresses Found in the Viewstate
+   10032-2:
+      alertid: 10032-2
+      name: Emails Found in the Viewstate
+   10032-3:
+      alertid: 10032-3
+      name: Old Asp.Net Version in Use
+   10032-4:
+      alertid: 10032-4
+      name: Viewstate without MAC Signature (Unsure)
+   10032-5:
+      alertid: 10032-5
+      name: Viewstate without MAC Signature (Sure)
+   10032-6:
+      alertid: 10032-6
+      name: Split Viewstate in Use
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Potential IP Addresses Found in the Viewstate
-
-### Type: Passive Scan Rule
-
-### Risk: Medium
-
-### Description
-
-The following potential IP addresses were found being serialized in the viewstate field:
-
-### Solution
-
-Verify the provided information isn't confidential.
-
-### CWE: [16](https://cwe.mitre.org/data/definitions/16.html)
-
-### WASC:  14
-
-## Name: Emails Found in the Viewstate
-
-### Risk: Medium
-
-### Description
-
-The following emails were found being serialized in the viewstate field:
-
-### Solution
-
-Verify the provided information isn't confidential.
-
-### CWE: [16](https://cwe.mitre.org/data/definitions/16.html)
-
-### WASC:  14
-
-## Name: Old Asp.Net Version in Use
-
-### Risk: Low
-
-### Description
-
-*** EXPERIMENTAL ***
-This website uses ASP.NET version 1.0 or 1.1.
-
-
-
-### Solution
-
-Ensure the engaged framework is still supported by Microsoft.
-
-### CWE: [16](https://cwe.mitre.org/data/definitions/16.html)
-
-### WASC:  14
-
-## Name: Viewstate without MAC Signature (Unsure)
-
-### Risk: High
-
-### Description
-
-*** EXPERIMENTAL ***
-This website uses ASP.NET's Viewstate but maybe without any MAC.
-
-
-
-### Solution
-
-Ensure the MAC is set for all pages on this website.
-
-### References
-
-* http://msdn.microsoft.com/en-us/library/ff649308.aspx
-
-### CWE: [642](https://cwe.mitre.org/data/definitions/642.html)
-
-### WASC:  14
-
-## Name: Viewstate without MAC Signature (Sure)
-
-### Risk: High
-
-### Description
-
-*** EXPERIMENTAL ***
-This website uses ASP.NET's Viewstate but without any MAC.
-
-
-
-### Solution
-
-Ensure the MAC is set for all pages on this website.
-
-### References
-
-* http://msdn.microsoft.com/en-us/library/ff649308.aspx
-
-### CWE: [642](https://cwe.mitre.org/data/definitions/642.html)
-
-### WASC:  14
-
-## Name: Split Viewstate in Use
-
-### Risk: Informational
-
-### Description
-
-*** EXPERIMENTAL ***
-This website uses ASP.NET's Viewstate and its value is split into several chunks.
-
-
-### Solution
-
-None - the guys running the server may have tuned the configuration as this isn't the default setting.
-
-### CWE: [16](https://cwe.mitre.org/data/definitions/16.html)
-
-### WASC:  14
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10033.md
+++ b/site/content/docs/alerts/10033.md
@@ -1,32 +1,16 @@
 ---
 title: "Directory Browsing"
 alertid: 10033
+alertindex: 1003300
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Configure the web server to disable directory browsing. "
+references:
+   - https://cwe.mitre.org/data/definitions/548.html
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Directory Browsing
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 It is possible to view a listing of the directory contents. Directory listings may reveal hidden scripts, include files , backup source files, etc., which be accessed to reveal sensitive information.
-
-### Solution
-
-Configure the web server to disable directory browsing. 
-
-### References
-
-* https://cwe.mitre.org/data/definitions/548.html
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10034.md
+++ b/site/content/docs/alerts/10034.md
@@ -1,32 +1,16 @@
 ---
 title: "Heartbleed OpenSSL Vulnerability (Indicative)"
 alertid: 10034
+alertindex: 1003400
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Update to OpenSSL 1.0.1g or later. Re-issue HTTPS certificates. Change asymmetric private keys and shared secret keys, since these may have been compromised, with no evidence of compromise in the server log files."
+references:
+   - http://cvedetails.com/cve-details.php?t=1&cve_id=CVE-2014-0160
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Heartbleed OpenSSL Vulnerability (Indicative)
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The TLS and DTLS implementations in OpenSSL 1.0.1 before 1.0.1g do not properly handle Heartbeat Extension packets, which allows remote attackers to obtain sensitive information from process memory via crafted packets that trigger a buffer over-read, potentially disclosing sensitive information.	
-
-### Solution
-
-Update to OpenSSL 1.0.1g or later. Re-issue HTTPS certificates. Change asymmetric private keys and shared secret keys, since these may have been compromised, with no evidence of compromise in the server log files.
-
-### References
-
-* http://cvedetails.com/cve-details.php?t=1&cve_id=CVE-2014-0160
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10035.md
+++ b/site/content/docs/alerts/10035.md
@@ -1,36 +1,20 @@
 ---
 title: "Strict-Transport-Security Header"
 alertid: 10035
+alertindex: 1003500
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that your web server, application server, load balancer, etc. is configured to enforce Strict-Transport-Security."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
+   - https://owasp.org/www-community/Security_Headers
+   - http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
+   - http://caniuse.com/stricttransportsecurity
+   - http://tools.ietf.org/html/rfc6797
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Strict-Transport-Security Header
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 HTTP Strict Transport Security (HSTS) is a web security policy mechanism whereby a web server declares that complying user agents (such as a web browser) are to interact with it using only secure HTTPS connections (i.e. HTTP layered over TLS/SSL). HSTS is an IETF standards track protocol and is specified in RFC 6797.
-
-### Solution
-
-Ensure that your web server, application server, load balancer, etc. is configured to enforce Strict-Transport-Security.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
-* https://owasp.org/www-community/Security_Headers
-* http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
-* http://caniuse.com/stricttransportsecurity
-* http://tools.ietf.org/html/rfc6797
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10036.md
+++ b/site/content/docs/alerts/10036.md
@@ -1,28 +1,14 @@
 ---
 title: "HTTP Server Response Header"
 alertid: 10036
+alertindex: 1003600
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "_Unavailable_"
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: HTTP Server Response Header
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 _Unavailable_
-
-### Solution
-
-_Unavailable_
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10037.md
+++ b/site/content/docs/alerts/10037.md
@@ -1,33 +1,17 @@
 ---
 title: "Server Leaks Information via 'X-Powered-By' HTTP Response Header Field(s)"
 alertid: 10037
+alertindex: 1003700
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that your web server, application server, load balancer, etc. is configured to suppress 'X-Powered-By' headers."
+references:
+   - http://blogs.msdn.com/b/varunm/archive/2013/04/23/remove-unwanted-http-response-headers.aspx
+   - http://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s)
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The web/application server is leaking information via one or more "X-Powered-By" HTTP response headers. Access to such information may facilitate attackers identifying other frameworks/components your web application is reliant upon and the vulnerabilities such components may be subject to.
-
-### Solution
-
-Ensure that your web server, application server, load balancer, etc. is configured to suppress "X-Powered-By" headers.
-
-### References
-
-* http://blogs.msdn.com/b/varunm/archive/2013/04/23/remove-unwanted-http-response-headers.aspx
-* http://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10038.md
+++ b/site/content/docs/alerts/10038.md
@@ -1,38 +1,22 @@
 ---
 title: "Content Security Policy (CSP) Header Not Set"
 alertid: 10038
+alertindex: 1003800
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header, to achieve optimal browser support: 'Content-Security-Policy' for Chrome 25+, Firefox 23+ and Safari 7+, 'X-Content-Security-Policy' for Firefox 4.0+ and Internet Explorer 10+, and 'X-WebKit-CSP' for Chrome 14+ and Safari 6+."
+references:
+   - https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy
+   - https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
+   - http://www.w3.org/TR/CSP/
+   - http://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html
+   - http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+   - http://caniuse.com/#feat=contentsecuritypolicy
+   - http://content-security-policy.com/
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Content Security Policy (CSP) Header Not Set
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.
-
-### Solution
-
-Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header, to achieve optimal browser support: "Content-Security-Policy" for Chrome 25+, Firefox 23+ and Safari 7+, "X-Content-Security-Policy" for Firefox 4.0+ and Internet Explorer 10+, and "X-WebKit-CSP" for Chrome 14+ and Safari 6+.
-
-### References
-
-* https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy
-* https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
-* http://www.w3.org/TR/CSP/
-* http://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html
-* http://www.html5rocks.com/en/tutorials/security/content-security-policy/
-* http://caniuse.com/#feat=contentsecuritypolicy
-* http://content-security-policy.com/
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10039.md
+++ b/site/content/docs/alerts/10039.md
@@ -1,28 +1,14 @@
 ---
 title: "X-Backend-Server Header Information Leak"
 alertid: 10039
+alertindex: 1003900
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that your web server, application server, load balancer, etc. is configured to suppress X-Backend-Server headers."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: X-Backend-Server Header Information Leak
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The server is leaking information pertaining to backend systems (such as hostnames or IP addresses). Armed with this information an attacker may be able to attack other systems or more directly/efficiently attack those systems.
-
-### Solution
-
-Ensure that your web server, application server, load balancer, etc. is configured to suppress X-Backend-Server headers.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10040.md
+++ b/site/content/docs/alerts/10040.md
@@ -1,34 +1,18 @@
 ---
 title: "Secure Pages Include Mixed Content"
 alertid: 10040
+alertindex: 1004000
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Secure Pages Include Mixed Content
-
-### Type: Passive Scan Rule
-
-
-### Description
-
-The page includes mixed content, that is content accessed via HTTP instead of HTTPS.
-
-### Solution
-
-A page that is available over SSL/TLS must be comprised completely of content which is transmitted over SSL/TLS.
+solution: "A page that is available over SSL/TLS must be comprised completely of content which is transmitted over SSL/TLS.
 The page must not contain any content that is transmitted over unencrypted HTTP.
- This includes content from third party sites.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+ This includes content from third party sites."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+The page includes mixed content, that is content accessed via HTTP instead of HTTPS.

--- a/site/content/docs/alerts/10041.md
+++ b/site/content/docs/alerts/10041.md
@@ -1,28 +1,14 @@
 ---
 title: "HTTP to HTTPS Insecure Transition in Form Post"
 alertid: 10041
+alertindex: 1004100
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Use HTTPS for landing pages that host secure forms."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: HTTP to HTTPS Insecure Transition in Form Post
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 This check looks for insecure HTTP pages that host HTTPS forms. The issue is that an insecure HTTP page can easily be hijacked through MITM and the secure HTTPS form can be replaced or spoofed.
-
-### Solution
-
-Use HTTPS for landing pages that host secure forms.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10042.md
+++ b/site/content/docs/alerts/10042.md
@@ -1,28 +1,14 @@
 ---
 title: "HTTPS to HTTP Insecure Transition in Form Post"
 alertid: 10042
+alertindex: 1004200
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure sensitive data is only sent over secured HTTPS channels."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: HTTPS to HTTP Insecure Transition in Form Post
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 This check identifies secure HTTPS pages that host insecure HTTP forms. The issue is that a secure page is transitioning to an insecure page when data is uploaded through a form. The user may think they're submitting data to a secure page when in fact they are not.
-
-### Solution
-
-Ensure sensitive data is only sent over secured HTTPS channels.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10043.md
+++ b/site/content/docs/alerts/10043.md
@@ -1,32 +1,16 @@
 ---
 title: "User Controllable JavaScript Event (XSS)"
 alertid: 10043
+alertindex: 1004300
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Validate all input and sanitize output it before writing to any Javascript on* events."
+references:
+   - http://websecuritytool.codeplex.com/wikipage?title=Checks#user-javascript-event
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: User Controllable JavaScript Event (XSS)
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.            
-
-### Solution
-
-Validate all input and sanitize output it before writing to any Javascript on* events.
-
-### References
-
-* http://websecuritytool.codeplex.com/wikipage?title=Checks#user-javascript-event
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10044.md
+++ b/site/content/docs/alerts/10044.md
@@ -1,28 +1,14 @@
 ---
 title: "Big Redirect Detected (Potential Sensitive Information Leak)"
 alertid: 10044
+alertindex: 1004400
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that no sensitive information is leaked via redirect responses. Redirect responses should have almost no content."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Big Redirect Detected (Potential Sensitive Information Leak)
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The server has responded with a redirect that seems to provide a large response. This may indicate that although the server sent a redirect it also responded with body content (which may include sensitive details, PII, etc.).
-
-### Solution
-
-Ensure that no sensitive information is leaked via redirect responses. Redirect responses should have almost no content.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10045.md
+++ b/site/content/docs/alerts/10045.md
@@ -1,42 +1,24 @@
 ---
 title: "Source Code Disclosure - /WEB-INF folder"
 alertid: 10045
+alertindex: 1004500
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Apply appropriate access control authorizations for each access to all restricted URLs, scripts or files.
+
+Consider using MVC based frameworks such as Struts."
+references:
+   - http://projects.webappsec.org/Predictable-Resource-Location
+   - http://cwe.mitre.org/data/definitions/425.html
+cwe: 541
+wasc: 34
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Source Code Disclosure - /WEB-INF folder
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 Predictable Resource Location is an attack technique used to uncover hidden web site content and functionality. By making educated guesses via brute forcing an attacker can guess file and directory names not intended for public viewing. Brute forcing filenames is easy because files/paths often have common naming convention and reside in standard locations. These can include temporary files, backup files, logs, administrative site sections, configuration files, demo applications, and sample files. These files may disclose sensitive information about the website, web application internals, database information, passwords, machine names, file paths to other sensitive areas, etc...
 
 This will not only assist with identifying site surface which may lead to additional site vulnerabilities, but also may disclose valuable information to an attacker about the environment or its users. Predictable Resource Location is also known as Forced Browsing, Forceful Browsing, File Enumeration, and Directory Enumeration.
-
-### Solution
-
-Apply appropriate access control authorizations for each access to all restricted URLs, scripts or files.
-
-Consider using MVC based frameworks such as Struts.
-
-### References
-
-* http://projects.webappsec.org/Predictable-Resource-Location
-* http://cwe.mitre.org/data/definitions/425.html
-
-### CWE: [541](https://cwe.mitre.org/data/definitions/541.html)
-
-### WASC:  34
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10046.md
+++ b/site/content/docs/alerts/10046.md
@@ -1,32 +1,19 @@
 ---
 title: "Insecure Component"
+name: "Insecure Component"
 alertid: 10046
+alertindex: 1004600
 alerttype: "Passive Scan Rule"
-status: alpha
+status: deprecated
 type: alert
-date: 2020-04-30 16:12:39.623Z
-lastmod: 2020-04-30 16:12:39.623Z
+date: 2020-10-30 12:12:42.788Z
+lastmod: 2020-10-30 12:12:42.788Z
 ---
-### Type: Passive Scan
-
-### Description
 Based on passive analysis of the response, insecure component {0} {1} appears to be in use.
 The highest noted CVSS rating for this product version is {2}.
 In total, {3} vulnerabilities were noted.
 Some Linux distributions such as Red Hat employ the practice of retaining old version numbers when security fixes are "backported".
 These cases are noted as "False Positives", but should be manually verified.  
 
-### Solution
-
-Upgrade from {0} {1} to the latest stable version of the product.
-Use a package manager and package management policies and procedures to manage the installed versions of software packages.
-
-### References
-
-* {0}
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesAlpha/InsecureComponentScanner.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InsecureComponentScanner.java)
-
-###### Last updated: 2020-04-30 16:12:39.623Z
+## Deprecated: 2020-02-07
+Replaced by the Retire rule which is actively maintained.

--- a/site/content/docs/alerts/10047.md
+++ b/site/content/docs/alerts/10047.md
@@ -1,41 +1,23 @@
 ---
 title: "HTTPS Content Available via HTTP"
 alertid: 10047
+alertindex: 1004700
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Low
+solution: "Ensure that your web server, application server, load balancer, etc. is configured to only serve such content via HTTPS. Consider implementing HTTP Strict Transport Security."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
+   - https://owasp.org/www-community/Security_Headers
+   - http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
+   - http://caniuse.com/stricttransportsecurity
+   - http://tools.ietf.org/html/rfc6797
+cwe: 311
+wasc: 4
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: HTTPS Content Available via HTTP
-
-### Type: Active Scan Rule
-
-### Risk: Low
-
-### Description
-
 Content which was initially accessed via HTTPS (i.e.: using SSL/TLS encryption) is also accessible via HTTP (without encryption). 
-
-### Solution
-
-Ensure that your web server, application server, load balancer, etc. is configured to only serve such content via HTTPS. Consider implementing HTTP Strict Transport Security.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
-* https://owasp.org/www-community/Security_Headers
-* http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
-* http://caniuse.com/stricttransportsecurity
-* http://tools.ietf.org/html/rfc6797
-
-### CWE: [311](https://cwe.mitre.org/data/definitions/311.html)
-
-### WASC:  4
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10048.md
+++ b/site/content/docs/alerts/10048.md
@@ -1,38 +1,20 @@
 ---
 title: "Remote Code Execution - Shell Shock"
 alertid: 10048
+alertindex: 1004800
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Update Bash on the server to the latest version"
+references:
+   - http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6271
+   - http://www.troyhunt.com/2014/09/everything-you-need-to-know-about.html
+cwe: 78
+wasc: 31
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Remote Code Execution - Shell Shock
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 The server is running a version of the Bash shell that allows remote attackers to execute arbitrary code 
-
-### Solution
-
-Update Bash on the server to the latest version
-
-### References
-
-* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6271
-* http://www.troyhunt.com/2014/09/everything-you-need-to-know-about.html
-
-### CWE: [78](https://cwe.mitre.org/data/definitions/78.html)
-
-### WASC:  31
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10049.md
+++ b/site/content/docs/alerts/10049.md
@@ -1,28 +1,14 @@
 ---
 title: "Content Cacheability"
 alertid: 10049
+alertindex: 1004900
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "_Unavailable_"
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Content Cacheability
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 _Unavailable_
-
-### Solution
-
-_Unavailable_
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10050.md
+++ b/site/content/docs/alerts/10050.md
@@ -1,38 +1,22 @@
 ---
 title: "Retrieved from Cache"
 alertid: 10050
+alertindex: 1005000
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Retrieved from Cache
-
-### Type: Passive Scan Rule
-
-
-### Description
-
-The content was retrieved from a shared cache. If the response data is sensitive, personal or user-specific, this may result in sensitive information being leaked. In some cases, this may even result in a user gaining complete control of the session of another user, depending on the configuration of the caching components in use in their environment. This is primarily an issue where caching servers such as "proxy" caches are configured on the local network. This configuration is typically found in corporate or educational environments, for instance. 
-
-### Solution
-
-Validate that the response does not contain sensitive, personal or user-specific information.  If it does, consider the use of the following HTTP response headers, to limit, or prevent the content being stored and retrieved from the cache by another user:
+solution: "Validate that the response does not contain sensitive, personal or user-specific information.  If it does, consider the use of the following HTTP response headers, to limit, or prevent the content being stored and retrieved from the cache by another user:
 Cache-Control: no-cache, no-store, must-revalidate, private
 Pragma: no-cache
 Expires: 0
-This configuration directs both HTTP 1.0 and HTTP 1.1 compliant caching servers to not store the response, and to not retrieve the response (without validation) from the cache, in response to a similar request.
-
-### References
-
-* https://tools.ietf.org/html/rfc7234
-* https://tools.ietf.org/html/rfc7231
-* http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html (obsoleted by rfc7234)
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+This configuration directs both HTTP 1.0 and HTTP 1.1 compliant caching servers to not store the response, and to not retrieve the response (without validation) from the cache, in response to a similar request."
+references:
+   - https://tools.ietf.org/html/rfc7234
+   - https://tools.ietf.org/html/rfc7231
+   - http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html (obsoleted by rfc7234)
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+The content was retrieved from a shared cache. If the response data is sensitive, personal or user-specific, this may result in sensitive information being leaked. In some cases, this may even result in a user gaining complete control of the session of another user, depending on the configuration of the caching components in use in their environment. This is primarily an issue where caching servers such as "proxy" caches are configured on the local network. This configuration is typically found in corporate or educational environments, for instance. 

--- a/site/content/docs/alerts/10051.md
+++ b/site/content/docs/alerts/10051.md
@@ -1,44 +1,26 @@
 ---
 title: "Relative Path Confusion"
 alertid: 10051
+alertindex: 1005100
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Web servers and frameworks should be updated to be configured to not serve responses to ambiguous URLs in such a way that the relative path of such URLs could be mis-interpreted by components on either the client side, or server side.
+Within the application, the correct use of the '<base>' HTML tag in the HTTP response will unambiguously specify the base URL for all relative URLs in the document.
+Use the 'Content-Type' HTTP response header to make it harder for the attacker to force the web browser to mis-interpret the content type of the response.
+Use the 'X-Content-Type-Options: nosniff' HTTP response header to prevent the web browser from 'sniffing' the content type of the response.
+Use a modern DOCTYPE such as '<!doctype html>' to prevent the page from being rendered in the web browser using 'Quirks Mode', since this results in the content type being ignored by the web browser.
+Specify the 'X-Frame-Options' HTTP response header to prevent Quirks Mode from being enabled in the web browser using framing attacks. "
+references:
+   - http://www.thespanner.co.uk/2014/03/21/rpo/
+   - https://hsivonen.fi/doctype/
+   - http://www.w3schools.com/tags/tag_base.asp
+cwe: 20
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Relative Path Confusion
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 The web server is configured to serve responses to ambiguous URLs in a manner that is likely to lead to confusion about the correct "relative path" for the URL. Resources (CSS, images, etc.) are also specified in the page response using relative, rather than absolute URLs. In an attack, if the web browser parses the "cross-content" response in a permissive manner, or can be tricked into permissively parsing the "cross-content" response, using techniques such as framing, then the web browser may be fooled into interpreting HTML as CSS (or other content types), leading to an XSS vulnerability.
-
-### Solution
-
-Web servers and frameworks should be updated to be configured to not serve responses to ambiguous URLs in such a way that the relative path of such URLs could be mis-interpreted by components on either the client side, or server side.
-Within the application, the correct use of the "<base>" HTML tag in the HTTP response will unambiguously specify the base URL for all relative URLs in the document.
-Use the "Content-Type" HTTP response header to make it harder for the attacker to force the web browser to mis-interpret the content type of the response.
-Use the "X-Content-Type-Options: nosniff" HTTP response header to prevent the web browser from "sniffing" the content type of the response.
-Use a modern DOCTYPE such as "<!doctype html>" to prevent the page from being rendered in the web browser using "Quirks Mode", since this results in the content type being ignored by the web browser.
-Specify the "X-Frame-Options" HTTP response header to prevent Quirks Mode from being enabled in the web browser using framing attacks. 
-
-### References
-
-* http://www.thespanner.co.uk/2014/03/21/rpo/
-* https://hsivonen.fi/doctype/
-* http://www.w3schools.com/tags/tag_base.asp
-
-### CWE: [20](https://cwe.mitre.org/data/definitions/20.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10052.md
+++ b/site/content/docs/alerts/10052.md
@@ -1,32 +1,16 @@
 ---
 title: "X-ChromeLogger-Data (XCOLD) Header Information Leak"
 alertid: 10052
+alertindex: 1005200
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Disable this functionality in Production when it might leak information that could be leveraged by an attacker. Alternatively ensure that use of the functionality is tied to a strong authorization check and only available to administrators or support personnel for troubleshooting purposes not general users."
+references:
+   - https://craig.is/writing/chrome-logger
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: X-ChromeLogger-Data (XCOLD) Header Information Leak
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The server is leaking information through the X-ChromeLogger-Data (or X-ChromePhp-Data) response header. The content of such headers can be customized by the developer, however it is not uncommon to find: server file system locations, vhost declarations, etc.
-
-### Solution
-
-Disable this functionality in Production when it might leak information that could be leveraged by an attacker. Alternatively ensure that use of the functionality is tied to a strong authorization check and only available to administrators or support personnel for troubleshooting purposes not general users.
-
-### References
-
-* https://craig.is/writing/chrome-logger
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10053.md
+++ b/site/content/docs/alerts/10053.md
@@ -1,38 +1,20 @@
 ---
 title: "Apache Range Header DoS (CVE-2011-3192)"
 alertid: 10053
+alertindex: 1005300
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Upgrade your Apache server to a currently stable version. Alternative solutions or workarounds are outlined in the references. "
+references:
+   - https://httpd.apache.org/security/CVE-2011-3192.txt
+   - http://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2011-3192
+cwe: 400
+wasc: 10
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ApacheRangeHeaderDosScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Apache Range Header DoS (CVE-2011-3192)
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 The byterange filter in earlier versions of the Apache HTTP Server allows remote attackers to cause a denial of service (memory and CPU exhaustion) via a Range request header that identifies multiple overlapping ranges. This issue was exploited in the wild in August 2011.
-
-### Solution
-
-Upgrade your Apache server to a currently stable version. Alternative solutions or workarounds are outlined in the references. 
-
-### References
-
-* https://httpd.apache.org/security/CVE-2011-3192.txt
-* http://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2011-3192
-
-### CWE: [400](https://cwe.mitre.org/data/definitions/400.html)
-
-### WASC:  10
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/ApacheRangeHeaderDosScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ApacheRangeHeaderDosScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10054.md
+++ b/site/content/docs/alerts/10054.md
@@ -1,32 +1,16 @@
 ---
 title: "Cookie Without SameSite Attribute"
 alertid: 10054
+alertindex: 1005400
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that the SameSite attribute is set to either 'lax' or ideally 'strict' for all cookies."
+references:
+   - https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cookie Without SameSite Attribute
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 A cookie has been set without the SameSite attribute, which means that the cookie can be sent as a result of a 'cross-site' request. The SameSite attribute is an effective counter measure to cross-site request forgery, cross-site script inclusion, and timing attacks.
-
-### Solution
-
-Ensure that the SameSite attribute is set to either 'lax' or ideally 'strict' for all cookies.
-
-### References
-
-* https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10055.md
+++ b/site/content/docs/alerts/10055.md
@@ -1,37 +1,21 @@
 ---
 title: "CSP"
 alertid: 10055
+alertindex: 1005500
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that your web server, application server, load balancer, etc. is properly configured to set the Content-Security-Policy header."
+references:
+   - http://www.w3.org/TR/CSP2/
+   - http://www.w3.org/TR/CSP/
+   - http://caniuse.com/#search=content+security+policy
+   - http://content-security-policy.com/
+   - https://github.com/shapesecurity/salvation
+   - https://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: CSP
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks. Including (but not limited to) Cross Site Scripting (XSS), and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.
-
-### Solution
-
-Ensure that your web server, application server, load balancer, etc. is properly configured to set the Content-Security-Policy header.
-
-### References
-
-* http://www.w3.org/TR/CSP2/
-* http://www.w3.org/TR/CSP/
-* http://caniuse.com/#search=content+security+policy
-* http://content-security-policy.com/
-* https://github.com/shapesecurity/salvation
-* https://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10056.md
+++ b/site/content/docs/alerts/10056.md
@@ -1,33 +1,17 @@
 ---
 title: "X-Debug-Token Information Leak"
 alertid: 10056
+alertindex: 1005600
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Limit access to Symfony's Profiler, either via authentication/authorization or limiting inclusion of the header to specific clients (by IP, etc.)."
+references:
+   - https://symfony.com/doc/current/cookbook/profiler/profiling_data.html
+   - https://symfony.com/blog/new-in-symfony-2-4-quicker-access-to-the-profiler-when-working-on-an-api
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: X-Debug-Token Information Leak
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The response contained an X-Debug-Token or X-Debug-Token-Link header. This indicates that Symfony's Profiler may be in use and exposing sensitive data.
-
-### Solution
-
-Limit access to Symfony's Profiler, either via authentication/authorization or limiting inclusion of the header to specific clients (by IP, etc.).
-
-### References
-
-* https://symfony.com/doc/current/cookbook/profiler/profiling_data.html
-* https://symfony.com/blog/new-in-symfony-2-4-quicker-access-to-the-profiler-when-working-on-an-api
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10057.md
+++ b/site/content/docs/alerts/10057.md
@@ -1,32 +1,16 @@
 ---
 title: "Username Hash Found"
 alertid: 10057
+alertindex: 1005700
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Use per user or session indirect object references (create a temporary mapping at time of use). Or, ensure that each use of a direct object reference is tied to an authorization check to ensure the user is authorized for the requested object. "
+references:
+   - https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References.html
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Username Hash Found
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 A hash of a username ({0}) was found in the response. This may indicate that the application is subject to an Insecure Direct Object Reference (IDOR) vulnerability. Manual testing will be required to see if this discovery can be abused.
-
-### Solution
-
-Use per user or session indirect object references (create a temporary mapping at time of use). Or, ensure that each use of a direct object reference is tied to an authorization check to ensure the user is authorized for the requested object. 
-
-### References
-
-* https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References.html
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10058.md
+++ b/site/content/docs/alerts/10058.md
@@ -1,33 +1,17 @@
 ---
 title: "GET for POST"
 alertid: 10058
+alertindex: 1005800
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Informational
+solution: "Ensure that only POST is accepted where POST is expected."
+cwe: 16
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GetForPostScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: GET for POST
-
-### Type: Active Scan Rule
-
-### Risk: Informational
-
-### Description
-
 A request that was originally observed as a POST was also accepted as a GET. This issue does not represent a security weakness unto itself, however, it may facilitate simplification of other attacks. For example if the original POST is subject to Cross-Site Scripting (XSS), then this finding may indicate that a simplified (GET based) XSS may also be possible.
-
-### Solution
-
-Ensure that only POST is accepted where POST is expected.
-
-### CWE: [16](https://cwe.mitre.org/data/definitions/16.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/GetForPostScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GetForPostScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10061.md
+++ b/site/content/docs/alerts/10061.md
@@ -1,33 +1,17 @@
 ---
 title: "X-AspNet-Version Response Header"
 alertid: 10061
+alertindex: 1006100
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Configure the server so it will not return those headers."
+references:
+   - https://www.troyhunt.com/shhh-dont-let-your-response-headers/
+   - https://blogs.msdn.microsoft.com/varunm/2013/04/23/remove-unwanted-http-response-headers/
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: X-AspNet-Version Response Header
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Server leaks information via "X-AspNet-Version"/"X-AspNetMvc-Version" HTTP response header field(s).
-
-### Solution
-
-Configure the server so it will not return those headers.
-
-### References
-
-* https://www.troyhunt.com/shhh-dont-let-your-response-headers/
-* https://blogs.msdn.microsoft.com/varunm/2013/04/23/remove-unwanted-http-response-headers/
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10062.md
+++ b/site/content/docs/alerts/10062.md
@@ -1,28 +1,14 @@
 ---
 title: "PII Disclosure"
 alertid: 10062
+alertindex: 1006200
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "_Unavailable_"
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: PII Disclosure
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
-
-### Solution
-
-_Unavailable_
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10063.md
+++ b/site/content/docs/alerts/10063.md
@@ -1,36 +1,20 @@
 ---
 title: "Feature Policy Header Not Set"
 alertid: 10063
+alertindex: 1006300
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that your web server, application server, load balancer, etc. is configured to set the Feature-Policy header."
+references:
+   - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
+   - https://developers.google.com/web/updates/2018/06/feature-policy
+   - https://scotthelme.co.uk/a-new-security-header-feature-policy/
+   - https://w3c.github.io/webappsec-feature-policy/
+   - https://www.smashingmagazine.com/2018/12/feature-policy/
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Feature Policy Header Not Set
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Feature Policy Header is an added layer of security that helps to restrict from unauthorized access or usage of browser/client features by web resources. This policy ensures the user privacy by limiting or specifying the features of the browsers can be used by the web resources. Feature Policy provides a set of standard HTTP headers that allow website owners to limit which features of browsers can be used by the page such as camera, microphone, location, full screen etc.
-
-### Solution
-
-Ensure that your web server, application server, load balancer, etc. is configured to set the Feature-Policy header.
-
-### References
-
-* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
-* https://developers.google.com/web/updates/2018/06/feature-policy
-* https://scotthelme.co.uk/a-new-security-header-feature-policy/
-* https://w3c.github.io/webappsec-feature-policy/
-* https://www.smashingmagazine.com/2018/12/feature-policy/
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10070.md
+++ b/site/content/docs/alerts/10070.md
@@ -1,28 +1,14 @@
 ---
 title: "Use of SAML"
 alertid: 10070
+alertindex: 1007000
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "_Unavailable_"
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLPassiveScanner.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Use of SAML
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 _Unavailable_
-
-### Solution
-
-_Unavailable_
-
-### Code
-
- * [org/zaproxy/zap/extension/saml/SAMLPassiveScanner.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLPassiveScanner.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10094.md
+++ b/site/content/docs/alerts/10094.md
@@ -1,32 +1,16 @@
 ---
 title: "Base64 Disclosure"
 alertid: 10094
+alertindex: 1009400
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Manually confirm that the Base64 data does not leak sensitive information, and that the data cannot be aggregated/used to exploit other vulnerabilities."
+references:
+   - http://projects.webappsec.org/w/page/13246936/Information%20Leakage
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Base64 Disclosure
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Base64 encoded data was disclosed by the application/web server. Note: in the interests of performance not all base64 strings in the response were analyzed individually, the entire response should be looked at by the analyst/security team/developer(s).
-
-### Solution
-
-Manually confirm that the Base64 data does not leak sensitive information, and that the data cannot be aggregated/used to exploit other vulnerabilities.
-
-### References
-
-* http://projects.webappsec.org/w/page/13246936/Information%20Leakage
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10095.md
+++ b/site/content/docs/alerts/10095.md
@@ -1,40 +1,22 @@
 ---
 title: "Backup File Disclosure"
 alertid: 10095
+alertindex: 1009500
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Apply appropriate access control authorizations for each access to all restricted URLs, scripts or files.
+
+Consider using MVC based frameworks such as Struts."
+references:
+   - https://cwe.mitre.org/data/definitions/530.html
+   - https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information.html
+cwe: 530
+wasc: 34
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Backup File Disclosure
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 A backup of the file was disclosed by the web server
-
-### Solution
-
-Apply appropriate access control authorizations for each access to all restricted URLs, scripts or files.
-
-Consider using MVC based frameworks such as Struts.
-
-### References
-
-* https://cwe.mitre.org/data/definitions/530.html
-* https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information.html
-
-### CWE: [530](https://cwe.mitre.org/data/definitions/530.html)
-
-### WASC:  34
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10096.md
+++ b/site/content/docs/alerts/10096.md
@@ -1,32 +1,16 @@
 ---
 title: "Timestamp Disclosure"
 alertid: 10096
+alertindex: 1009600
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Manually confirm that the timestamp data is not sensitive, and that the data cannot be aggregated to disclose exploitable patterns."
+references:
+   - http://projects.webappsec.org/w/page/13246936/Information%20Leakage
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Timestamp Disclosure
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 A timestamp was disclosed by the application/web server
-
-### Solution
-
-Manually confirm that the timestamp data is not sensitive, and that the data cannot be aggregated to disclose exploitable patterns.
-
-### References
-
-* http://projects.webappsec.org/w/page/13246936/Information%20Leakage
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10097.md
+++ b/site/content/docs/alerts/10097.md
@@ -1,33 +1,17 @@
 ---
 title: "Hash Disclosure"
 alertid: 10097
+alertindex: 1009700
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that hashes that are used to protect credentials or other resources are not leaked by the web server or database. There is typically no requirement for password hashes to be accessible to the web browser.      "
+references:
+   - http://projects.webappsec.org/w/page/13246936/Information%20Leakage
+   - http://openwall.info/wiki/john/sample-hashes
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Hash Disclosure
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 A hash was disclosed by the web server.
-
-### Solution
-
-Ensure that hashes that are used to protect credentials or other resources are not leaked by the web server or database. There is typically no requirement for password hashes to be accessible to the web browser.      
-
-### References
-
-* http://projects.webappsec.org/w/page/13246936/Information%20Leakage
-* http://openwall.info/wiki/john/sample-hashes
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10098.md
+++ b/site/content/docs/alerts/10098.md
@@ -1,33 +1,17 @@
 ---
 title: "Cross-Domain Misconfiguration"
 alertid: 10098
+alertindex: 1009800
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that sensitive data is not available in an unauthenticated manner (using IP address white-listing, for instance).
+Configure the 'Access-Control-Allow-Origin' HTTP header to a more restrictive set of domains, or remove all CORS headers entirely, to allow the web browser to enforce the Same Origin Policy (SOP) in a more restrictive manner."
+references:
+   - http://www.hpenterprisesecurity.com/vulncat/en/vulncat/vb/html5_overly_permissive_cors_policy.html
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cross-Domain Misconfiguration
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Web browser data loading may be possible, due to a Cross Origin Resource Sharing (CORS) misconfiguration on the web server
-
-### Solution
-
-Ensure that sensitive data is not available in an unauthenticated manner (using IP address white-listing, for instance).
-Configure the "Access-Control-Allow-Origin" HTTP header to a more restrictive set of domains, or remove all CORS headers entirely, to allow the web browser to enforce the Same Origin Policy (SOP) in a more restrictive manner.
-
-### References
-
-* http://www.hpenterprisesecurity.com/vulncat/en/vulncat/vb/html5_overly_permissive_cors_policy.html
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10099.md
+++ b/site/content/docs/alerts/10099.md
@@ -1,32 +1,16 @@
 ---
 title: "Source Code Disclosure"
 alertid: 10099
+alertindex: 1009900
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Ensure that application Source Code is not available with alternative extensions, and ensure that source code is not present within other files or data deployed to the web server, or served by the web server. "
+references:
+   - http://blogs.wsj.com/cio/2013/10/08/adobe-source-code-leak-is-bad-news-for-u-s-government/
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Source Code Disclosure
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Application Source Code was disclosed by the web server
-
-### Solution
-
-Ensure that application Source Code is not available with alternative extensions, and ensure that source code is not present within other files or data deployed to the web server, or served by the web server. 
-
-### References
-
-* http://blogs.wsj.com/cio/2013/10/08/adobe-source-code-leak-is-bad-news-for-u-s-government/
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10103.md
+++ b/site/content/docs/alerts/10103.md
@@ -1,32 +1,16 @@
 ---
 title: "Image Location and Privacy Scanner"
 alertid: 10103
+alertindex: 1010300
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Before allowing images to be stored on the server and/or transmitted to the browser, strip out the embedded location information from image.  This could mean removing all Exif data or just the GPS component.  Other data, like serial numbers, should also be removed."
+references:
+   - https://www.veggiespam.com/ils/
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Image Location and Privacy Scanner
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The image was found to contain embedded location information, such as GPS coordinates, or another privacy exposure, such as camera serial number.  Depending on the context of the image in the website, this information may expose private details of the users of a site.  For example, a site that allows users to upload profile pictures taken in the home may expose the home's address.  
-
-### Solution
-
-Before allowing images to be stored on the server and/or transmitted to the browser, strip out the embedded location information from image.  This could mean removing all Exif data or just the GPS component.  Other data, like serial numbers, should also be removed.
-
-### References
-
-* https://www.veggiespam.com/ils/
-
-### Code
-
- * [org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10104.md
+++ b/site/content/docs/alerts/10104.md
@@ -1,33 +1,17 @@
 ---
 title: "User Agent Fuzzer"
 alertid: 10104
+alertindex: 1010400
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Informational
+solution: ""
+references:
+   - https://owasp.org/wstg
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: User Agent Fuzzer
-
-### Type: Active Scan Rule
-
-### Risk: Informational
-
-### Description
-
 Check for differences in response based on fuzzed User Agent (eg. mobile sites, access as a Search Engine Crawler). Compares the response statuscode and the hashcode of the response body with the original response.
-
-### Solution
-
-
-
-### References
-
-* https://owasp.org/wstg
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10105.md
+++ b/site/content/docs/alerts/10105.md
@@ -1,32 +1,16 @@
 ---
 title: "Weak Authentication Method"
 alertid: 10105
+alertindex: 1010500
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Protect the connection using HTTPS or use a stronger authentication mechanism"
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Weak Authentication Method
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 HTTP basic or digest authentication has been used over an unsecured connection. The credentials can be read and then reused by someone with access to the network.
-
-### Solution
-
-Protect the connection using HTTPS or use a stronger authentication mechanism
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10106.md
+++ b/site/content/docs/alerts/10106.md
@@ -1,38 +1,20 @@
 ---
 title: "HTTP Only Site"
 alertid: 10106
+alertindex: 1010600
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Configure your web or application server to use SSL (https)."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html
+   - https://letsencrypt.org/
+cwe: 311
+wasc: 4
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: HTTP Only Site
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 The site is only served under HTTP and not HTTPS.
-
-### Solution
-
-Configure your web or application server to use SSL (https).
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html
-* https://letsencrypt.org/
-
-### CWE: [311](https://cwe.mitre.org/data/definitions/311.html)
-
-### WASC:  4
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10107.md
+++ b/site/content/docs/alerts/10107.md
@@ -1,41 +1,23 @@
 ---
 title: "Httpoxy - Proxy Header Misuse"
 alertid: 10107
+alertindex: 1010700
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "The best immediate mitigation is to block Proxy request headers as early as possible, and before they hit your application."
+references:
+   - https://httpoxy.org/
+cwe: 20
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttPoxyScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Httpoxy - Proxy Header Misuse
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 The server initiated a proxied request via the proxy specified in the HTTP Proxy header of the request.Httpoxy typically affects code running in CGI or CGI like environments.
 This may allow attackers to:
 * Proxy the outgoing HTTP requests made by the web application
 * Direct the server to open outgoing connections to an address and port of their choosing or
 * Tie up server resources by forcing the vulnerable software to use a malicious proxy
-
-### Solution
-
-The best immediate mitigation is to block Proxy request headers as early as possible, and before they hit your application.
-
-### References
-
-* https://httpoxy.org/
-
-### CWE: [20](https://cwe.mitre.org/data/definitions/20.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/HttPoxyScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttPoxyScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10108.md
+++ b/site/content/docs/alerts/10108.md
@@ -1,36 +1,19 @@
 ---
 title: "Reverse Tabnabbing"
 alertid: 10108
+alertindex: 1010800
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Do not use a target attribute, or if you have to then also add the attribute: rel='noopener noreferrer'."
+references:
+   - https://owasp.org/www-community/attacks/Reverse_Tabnabbing
+   - https://dev.to/ben/the-targetblank-vulnerability-by-example
+   - https://mathiasbynens.github.io/rel-noopener/
+   - https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Reverse Tabnabbing
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 At least one link on this page is vulnerable to Reverse tabnabbing as it uses a target attribute without using both of the "noopener" and "noreferrer" keywords in the "rel" attribute, which allows the target page to take control of this page.
-
-### Solution
-
-Do not use a target attribute, or if you have to then also add the attribute: rel="noopener noreferrer".
-
-### References
-
-* https://owasp.org/www-community/attacks/Reverse_Tabnabbing
-* https://dev.to/ben/the-targetblank-vulnerability-by-example
-* https://mathiasbynens.github.io/rel-noopener/
-* https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c
-* 
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10109.md
+++ b/site/content/docs/alerts/10109.md
@@ -1,28 +1,14 @@
 ---
 title: "Modern Web Application"
 alertid: 10109
+alertindex: 1010900
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "This is an informational alert and so no changes are required."
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Modern Web Application
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The application appears to be a modern web application. If you need to explore it automatically then the Ajax Spider may well be more effective than the standard one.
-
-### Solution
-
-This is an informational alert and so no changes are required.
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10110.md
+++ b/site/content/docs/alerts/10110.md
@@ -1,32 +1,16 @@
 ---
 title: "Dangerous JS Functions"
 alertid: 10110
+alertindex: 1011000
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "See the references for security advice on the use of these functions."
+references:
+   - https://angular.io/guide/security
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Dangerous JS Functions
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 A dangerous JS function seems to be in use that would leave the site vulnerable.
-
-### Solution
-
-See the references for security advice on the use of these functions.
-
-### References
-
-* https://angular.io/guide/security
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/10202.md
+++ b/site/content/docs/alerts/10202.md
@@ -1,32 +1,12 @@
 ---
 title: "Absence of Anti-CSRF Tokens"
 alertid: 10202
+alertindex: 1020200
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Absence of Anti-CSRF Tokens
-
-### Type: Passive Scan Rule
-
-
-### Description
-
-A cross-site request forgery is an attack that involves forcing a victim to send an HTTP request to a target destination without their knowledge or intent in order to perform an action as the victim. The underlying cause is application functionality using predictable URL/form actions in a repeatable way. The nature of the attack is that CSRF exploits the trust that a web site has for a user. By contrast, cross-site scripting (XSS) exploits the trust that a user has for a web site. Like XSS, CSRF attacks are not necessarily cross-site, but they can be. Cross-site request forgery is also known as CSRF, XSRF, one-click attack, session riding, confused deputy, and sea surf.
-
-CSRF attacks are effective in a number of situations, including:
-    * The victim has an active session on the target site.
-    * The victim is authenticated via HTTP auth on the target site.
-    * The victim is on the same local network as the target site.
-
-CSRF has primarily been used to perform an action against a target site using the victim's privileges, but recent techniques have been discovered to disclose information by gaining access to the response. The risk of information disclosure is dramatically increased when the target site is vulnerable to XSS, because XSS can be used as a platform for CSRF, allowing the attack to operate within the bounds of the same-origin policy.
-
-### Solution
-
-Phase: Architecture and Design
+solution: "Phase: Architecture and Design
 Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
 For example, use anti-CSRF packages such as the OWASP CSRFGuard.
 
@@ -46,15 +26,19 @@ This control includes a component for CSRF.
 Do not use the GET method for any request that triggers a state change.
 
 Phase: Implementation
-Check the HTTP Referer header to see if the request originated from an expected page. This could break legitimate functionality, because users or proxies may have disabled sending the Referer for privacy reasons.
+Check the HTTP Referer header to see if the request originated from an expected page. This could break legitimate functionality, because users or proxies may have disabled sending the Referer for privacy reasons."
+references:
+   - http://projects.webappsec.org/Cross-Site-Request-Forgery
+   - http://cwe.mitre.org/data/definitions/352.html
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+A cross-site request forgery is an attack that involves forcing a victim to send an HTTP request to a target destination without their knowledge or intent in order to perform an action as the victim. The underlying cause is application functionality using predictable URL/form actions in a repeatable way. The nature of the attack is that CSRF exploits the trust that a web site has for a user. By contrast, cross-site scripting (XSS) exploits the trust that a user has for a web site. Like XSS, CSRF attacks are not necessarily cross-site, but they can be. Cross-site request forgery is also known as CSRF, XSRF, one-click attack, session riding, confused deputy, and sea surf.
 
-### References
+CSRF attacks are effective in a number of situations, including:
+    * The victim has an active session on the target site.
+    * The victim is authenticated via HTTP auth on the target site.
+    * The victim is on the same local network as the target site.
 
-* http://projects.webappsec.org/Cross-Site-Request-Forgery
-* http://cwe.mitre.org/data/definitions/352.html
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+CSRF has primarily been used to perform an action against a target site using the victim's privileges, but recent techniques have been discovered to disclose information by gaining access to the response. The risk of information disclosure is dramatically increased when the target site is vulnerable to XSS, because XSS can be used as a platform for CSRF, allowing the attack to operate within the bounds of the same-origin policy.

--- a/site/content/docs/alerts/2.md
+++ b/site/content/docs/alerts/2.md
@@ -1,33 +1,17 @@
 ---
 title: "Private IP Disclosure"
 alertid: 2
+alertindex: 200
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Low
+solution: "Remove the private IP address from the HTTP response body.  For comments, use JSP/ASP/PHP comment instead of HTML/JavaScript comment which can be seen by client browsers."
+references:
+   - https://tools.ietf.org/html/rfc1918
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Private IP Disclosure
-
-### Type: Passive Scan Rule
-
-### Risk: Low
-
-### Description
-
 A private IP (such as 10.x.x.x, 172.x.x.x, 192.168.x.x) or an Amazon EC2 private hostname (for example, ip-10-0-56-78) has been found in the HTTP response body. This information might be helpful for further attacks targeting internal systems.
-
-### Solution
-
-Remove the private IP address from the HTTP response body.  For comments, use JSP/ASP/PHP comment instead of HTML/JavaScript comment which can be seen by client browsers.
-
-### References
-
-* https://tools.ietf.org/html/rfc1918
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/20012.md
+++ b/site/content/docs/alerts/20012.md
@@ -1,33 +1,13 @@
 ---
 title: "Anti-CSRF Tokens Check"
 alertid: 20012
+alertindex: 2001200
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Anti-CSRF Tokens Check
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-A cross-site request forgery is an attack that involves forcing a victim to send an HTTP request to a target destination without their knowledge or intent in order to perform an action as the victim. The underlying cause is application functionality using predictable URL/form actions in a repeatable way. The nature of the attack is that CSRF exploits the trust that a web site has for a user. By contrast, cross-site scripting (XSS) exploits the trust that a user has for a web site. Like XSS, CSRF attacks are not necessarily cross-site, but they can be. Cross-site request forgery is also known as CSRF, XSRF, one-click attack, session riding, confused deputy, and sea surf.
-
-CSRF attacks are effective in a number of situations, including:
-    * The victim has an active session on the target site.
-    * The victim is authenticated via HTTP auth on the target site.
-    * The victim is on the same local network as the target site.
-
-CSRF has primarily been used to perform an action against a target site using the victim's privileges, but recent techniques have been discovered to disclose information by gaining access to the response. The risk of information disclosure is dramatically increased when the target site is vulnerable to XSS, because XSS can be used as a platform for CSRF, allowing the attack to operate within the bounds of the same-origin policy.
-
-### Solution
-
-Phase: Architecture and Design
+risk: High
+solution: "Phase: Architecture and Design
 Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
 For example, use anti-CSRF packages such as the OWASP CSRFGuard.
 
@@ -47,19 +27,21 @@ This control includes a component for CSRF.
 Do not use the GET method for any request that triggers a state change.
 
 Phase: Implementation
-Check the HTTP Referer header to see if the request originated from an expected page. This could break legitimate functionality, because users or proxies may have disabled sending the Referer for privacy reasons.
+Check the HTTP Referer header to see if the request originated from an expected page. This could break legitimate functionality, because users or proxies may have disabled sending the Referer for privacy reasons."
+references:
+   - http://projects.webappsec.org/Cross-Site-Request-Forgery
+   - http://cwe.mitre.org/data/definitions/352.html
+cwe: 352
+wasc: 9
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+A cross-site request forgery is an attack that involves forcing a victim to send an HTTP request to a target destination without their knowledge or intent in order to perform an action as the victim. The underlying cause is application functionality using predictable URL/form actions in a repeatable way. The nature of the attack is that CSRF exploits the trust that a web site has for a user. By contrast, cross-site scripting (XSS) exploits the trust that a user has for a web site. Like XSS, CSRF attacks are not necessarily cross-site, but they can be. Cross-site request forgery is also known as CSRF, XSRF, one-click attack, session riding, confused deputy, and sea surf.
 
-### References
+CSRF attacks are effective in a number of situations, including:
+    * The victim has an active session on the target site.
+    * The victim is authenticated via HTTP auth on the target site.
+    * The victim is on the same local network as the target site.
 
-* http://projects.webappsec.org/Cross-Site-Request-Forgery
-* http://cwe.mitre.org/data/definitions/352.html
-
-### CWE: [352](https://cwe.mitre.org/data/definitions/352.html)
-
-### WASC:  9
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+CSRF has primarily been used to perform an action against a target site using the victim's privileges, but recent techniques have been discovered to disclose information by gaining access to the response. The risk of information disclosure is dramatically increased when the target site is vulnerable to XSS, because XSS can be used as a platform for CSRF, allowing the attack to operate within the bounds of the same-origin policy.

--- a/site/content/docs/alerts/20014.md
+++ b/site/content/docs/alerts/20014.md
@@ -1,37 +1,19 @@
 ---
 title: "HTTP Parameter Pollution"
 alertid: 20014
+alertindex: 2001400
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Informational
+solution: "Properly sanitize the user input for parameter delimiters"
+references:
+   - http://www.google.com/search?q=http+parameter+pollution
+cwe: 20
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: HTTP Parameter Pollution
-
-### Type: Active Scan Rule
-
-### Risk: Informational
-
-### Description
-
 HTTP Parameter Pollution (HPP) attacks consist of injecting encoded query string delimiters into other existing parameters. If a web application does not properly sanitize the user input, a malicious user can compromise the logic of the application to perform either client-side or server-side attacks. One consequence of HPP attacks is that the attacker can potentially override existing hard-coded HTTP parameters to modify the behavior of an application, bypass input validation checkpoints, and access and possibly exploit variables that may be out of direct reach.
-
-### Solution
-
-Properly sanitize the user input for parameter delimiters
-
-### References
-
-* http://www.google.com/search?q=http+parameter+pollution
-
-### CWE: [20](https://cwe.mitre.org/data/definitions/20.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/20015.md
+++ b/site/content/docs/alerts/20015.md
@@ -1,37 +1,19 @@
 ---
 title: "Heartbleed OpenSSL Vulnerability"
 alertid: 20015
+alertindex: 2001500
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Update to OpenSSL 1.0.1g or later. Re-issue HTTPS certificates. Change asymmetric private keys and shared secret keys, since these may have been compromised, with no evidence of compromise in the server log files."
+references:
+   - http://cvedetails.com/cve-details.php?t=1&cve_id=CVE-2014-0160
+cwe: 119
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Heartbleed OpenSSL Vulnerability
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 The TLS implementation in OpenSSL 1.0.1 before 1.0.1g does not properly handle Heartbeat Extension packets, which allows remote attackers to obtain sensitive information from process memory via crafted packets that trigger a buffer over-read, potentially disclosing sensitive information.
-
-### Solution
-
-Update to OpenSSL 1.0.1g or later. Re-issue HTTPS certificates. Change asymmetric private keys and shared secret keys, since these may have been compromised, with no evidence of compromise in the server log files.
-
-### References
-
-* http://cvedetails.com/cve-details.php?t=1&cve_id=CVE-2014-0160
-
-### CWE: [119](https://cwe.mitre.org/data/definitions/119.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/20016.md
+++ b/site/content/docs/alerts/20016.md
@@ -1,40 +1,22 @@
 ---
 title: "Cross-Domain Misconfiguration"
 alertid: 20016
+alertindex: 2001600
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: ""
+references:
+   - http://www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html
+   - http://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/CrossDomain_PolicyFile_Specification.pdf
+   - http://msdn.microsoft.com/en-US/library/cc197955%28v=vs.95%29.aspx
+   - http://msdn.microsoft.com/en-us/library/cc838250%28v=vs.95%29.aspx
+cwe: 264
+wasc: 14
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cross-Domain Misconfiguration
 
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-
-
-### Solution
-
-
-
-### References
-
-* http://www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html
-* http://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/CrossDomain_PolicyFile_Specification.pdf
-* http://msdn.microsoft.com/en-US/library/cc197955%28v=vs.95%29.aspx
-* http://msdn.microsoft.com/en-us/library/cc838250%28v=vs.95%29.aspx
-
-### CWE: [264](https://cwe.mitre.org/data/definitions/264.html)
-
-### WASC:  14
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/20017.md
+++ b/site/content/docs/alerts/20017.md
@@ -1,32 +1,13 @@
 ---
 title: "Source Code Disclosure - CVE-2012-1823"
 alertid: 20017
+alertindex: 2001700
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Source Code Disclosure - CVE-2012-1823
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-Improper input handling is one of the most common weaknesses identified across applications today. Poorly handled input is a leading cause behind critical vulnerabilities that exist in systems and applications.
-	
-Generally, the term input handing is used to describe functions like validation, sanitization, filtering, encoding and/or decoding of input data. Applications receive input from various sources including human users, software agents (browsers), and network/peripheral devices to name a few. In the case of web applications, input can be transferred in various formats (name value pairs, JSON, SOAP, etc...) and obtained via URL query strings, POST data, HTTP headers, Cookies, etc... Non-web application input can be obtained via application variables, environment variables, the registry, configuration files, etc... Regardless of the data format or source/location of the input, all input should be considered untrusted and potentially malicious. Applications which process untrusted input may become vulnerable to attacks such as Buffer Overflows, SQL Injection, OS Commanding, Denial of Service just to name a few.
-
-One of the key aspects of input handling is validating that the input satisfies a certain criteria. For proper validation, it is important to identify the form and type of data that is acceptable and expected by the application. Defining an expected format and usage of each instance of untrusted input is required to accurately define restrictions. 
-
-Validation can include checks for type safety and correct syntax. String input can be checked for length (min and max number of characters) and character set validation while numeric input types like integers and decimals can be validated against acceptable upper and lower bound of values. When combining input from multiple sources, validation should be performed during concatenation and not just against the individual data elements. This practice helps avoid situations where input validation may succeed when performed on individual data items but fails when done on a combined set from all the sources.
-
-### Solution
-
-Phase: Architecture and Design
+risk: High
+solution: "Phase: Architecture and Design
 
 Use an input validation framework such as Struts or the OWASP ESAPI Validation API.
 
@@ -40,9 +21,9 @@ Do not rely exclusively on deny list validation to detect malicious input or to 
 
 When your application combines data from multiple sources, perform the validation after the sources have been combined. The individual data elements may pass the validation step but violate the intended restrictions after they have been combined.
 
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
 
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
 
 Phase: Implementation
 
@@ -54,19 +35,20 @@ Inputs should be decoded and canonicalized to the application's current internal
 
 Consider performing repeated canonicalization until your input does not change any more. This will avoid double-decoding and similar scenarios, but it might inadvertently modify inputs that are allowed to contain properly-encoded dangerous content.
 
-When exchanging data between components, ensure that both components are using the same character encoding. Ensure that the proper encoding is applied at each interface. Explicitly set the encoding you are using whenever the protocol allows you to do so.
+When exchanging data between components, ensure that both components are using the same character encoding. Ensure that the proper encoding is applied at each interface. Explicitly set the encoding you are using whenever the protocol allows you to do so."
+references:
+   - http://projects.webappsec.org/Improper-Input-Handling
+   - http://cwe.mitre.org/data/definitions/89.html
+cwe: 20
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve0121823ScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+Improper input handling is one of the most common weaknesses identified across applications today. Poorly handled input is a leading cause behind critical vulnerabilities that exist in systems and applications.
+	
+Generally, the term input handing is used to describe functions like validation, sanitization, filtering, encoding and/or decoding of input data. Applications receive input from various sources including human users, software agents (browsers), and network/peripheral devices to name a few. In the case of web applications, input can be transferred in various formats (name value pairs, JSON, SOAP, etc...) and obtained via URL query strings, POST data, HTTP headers, Cookies, etc... Non-web application input can be obtained via application variables, environment variables, the registry, configuration files, etc... Regardless of the data format or source/location of the input, all input should be considered untrusted and potentially malicious. Applications which process untrusted input may become vulnerable to attacks such as Buffer Overflows, SQL Injection, OS Commanding, Denial of Service just to name a few.
 
-### References
+One of the key aspects of input handling is validating that the input satisfies a certain criteria. For proper validation, it is important to identify the form and type of data that is acceptable and expected by the application. Defining an expected format and usage of each instance of untrusted input is required to accurately define restrictions. 
 
-* http://projects.webappsec.org/Improper-Input-Handling
-* http://cwe.mitre.org/data/definitions/89.html
-
-### CWE: [20](https://cwe.mitre.org/data/definitions/20.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve0121823ScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve0121823ScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Validation can include checks for type safety and correct syntax. String input can be checked for length (min and max number of characters) and character set validation while numeric input types like integers and decimals can be validated against acceptable upper and lower bound of values. When combining input from multiple sources, validation should be performed during concatenation and not just against the individual data elements. This practice helps avoid situations where input validation may succeed when performed on individual data items but fails when done on a combined set from all the sources.

--- a/site/content/docs/alerts/20018.md
+++ b/site/content/docs/alerts/20018.md
@@ -1,32 +1,13 @@
 ---
 title: "Remote Code Execution - CVE-2012-1823"
 alertid: 20018
+alertindex: 2001800
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Remote Code Execution - CVE-2012-1823
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-Improper input handling is one of the most common weaknesses identified across applications today. Poorly handled input is a leading cause behind critical vulnerabilities that exist in systems and applications.
-	
-Generally, the term input handing is used to describe functions like validation, sanitization, filtering, encoding and/or decoding of input data. Applications receive input from various sources including human users, software agents (browsers), and network/peripheral devices to name a few. In the case of web applications, input can be transferred in various formats (name value pairs, JSON, SOAP, etc...) and obtained via URL query strings, POST data, HTTP headers, Cookies, etc... Non-web application input can be obtained via application variables, environment variables, the registry, configuration files, etc... Regardless of the data format or source/location of the input, all input should be considered untrusted and potentially malicious. Applications which process untrusted input may become vulnerable to attacks such as Buffer Overflows, SQL Injection, OS Commanding, Denial of Service just to name a few.
-
-One of the key aspects of input handling is validating that the input satisfies a certain criteria. For proper validation, it is important to identify the form and type of data that is acceptable and expected by the application. Defining an expected format and usage of each instance of untrusted input is required to accurately define restrictions. 
-
-Validation can include checks for type safety and correct syntax. String input can be checked for length (min and max number of characters) and character set validation while numeric input types like integers and decimals can be validated against acceptable upper and lower bound of values. When combining input from multiple sources, validation should be performed during concatenation and not just against the individual data elements. This practice helps avoid situations where input validation may succeed when performed on individual data items but fails when done on a combined set from all the sources.
-
-### Solution
-
-Phase: Architecture and Design
+risk: High
+solution: "Phase: Architecture and Design
 
 Use an input validation framework such as Struts or the OWASP ESAPI Validation API.
 
@@ -40,9 +21,9 @@ Do not rely exclusively on deny list validation to detect malicious input or to 
 
 When your application combines data from multiple sources, perform the validation after the sources have been combined. The individual data elements may pass the validation step but violate the intended restrictions after they have been combined.
 
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
 
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
 
 Phase: Implementation
 
@@ -54,19 +35,20 @@ Inputs should be decoded and canonicalized to the application's current internal
 
 Consider performing repeated canonicalization until your input does not change any more. This will avoid double-decoding and similar scenarios, but it might inadvertently modify inputs that are allowed to contain properly-encoded dangerous content.
 
-When exchanging data between components, ensure that both components are using the same character encoding. Ensure that the proper encoding is applied at each interface. Explicitly set the encoding you are using whenever the protocol allows you to do so.
+When exchanging data between components, ensure that both components are using the same character encoding. Ensure that the proper encoding is applied at each interface. Explicitly set the encoding you are using whenever the protocol allows you to do so."
+references:
+   - http://projects.webappsec.org/Improper-Input-Handling
+   - http://cwe.mitre.org/data/definitions/89.html
+cwe: 20
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve0121823ScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+Improper input handling is one of the most common weaknesses identified across applications today. Poorly handled input is a leading cause behind critical vulnerabilities that exist in systems and applications.
+	
+Generally, the term input handing is used to describe functions like validation, sanitization, filtering, encoding and/or decoding of input data. Applications receive input from various sources including human users, software agents (browsers), and network/peripheral devices to name a few. In the case of web applications, input can be transferred in various formats (name value pairs, JSON, SOAP, etc...) and obtained via URL query strings, POST data, HTTP headers, Cookies, etc... Non-web application input can be obtained via application variables, environment variables, the registry, configuration files, etc... Regardless of the data format or source/location of the input, all input should be considered untrusted and potentially malicious. Applications which process untrusted input may become vulnerable to attacks such as Buffer Overflows, SQL Injection, OS Commanding, Denial of Service just to name a few.
 
-### References
+One of the key aspects of input handling is validating that the input satisfies a certain criteria. For proper validation, it is important to identify the form and type of data that is acceptable and expected by the application. Defining an expected format and usage of each instance of untrusted input is required to accurately define restrictions. 
 
-* http://projects.webappsec.org/Improper-Input-Handling
-* http://cwe.mitre.org/data/definitions/89.html
-
-### CWE: [20](https://cwe.mitre.org/data/definitions/20.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve0121823ScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve0121823ScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Validation can include checks for type safety and correct syntax. String input can be checked for length (min and max number of characters) and character set validation while numeric input types like integers and decimals can be validated against acceptable upper and lower bound of values. When combining input from multiple sources, validation should be performed during concatenation and not just against the individual data elements. This practice helps avoid situations where input validation may succeed when performed on individual data items but fails when done on a combined set from all the sources.

--- a/site/content/docs/alerts/20019.md
+++ b/site/content/docs/alerts/20019.md
@@ -1,28 +1,15 @@
 ---
 title: "External Redirect"
 alertid: 20019
+alertindex: 2001900
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: External Redirect
+risk: High
+solution: "Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
 
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-URL redirectors represent common functionality employed by web sites to forward an incoming request to an alternate resource. This can be done for a variety of reasons and is often done to allow resources to be moved within the directory structure and to avoid breaking functionality for users that request the resource at its previous location. URL redirectors may also be used to implement load balancing, leveraging abbreviated URLs or recording outgoing links. It is this last implementation which is often used in phishing attacks as described in the example below. URL redirectors do not necessarily represent a direct security vulnerability but can be abused by attackers trying to social engineer victims into believing that they are navigating to a site other than the true destination.
-
-### Solution
-
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
-
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
 
 Use an allow list of approved URLs or domains to be used for redirection.
 
@@ -30,23 +17,18 @@ Use an intermediate disclaimer page that provides the user with a clear warning 
 
 When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs) to the actual filenames or URLs, and reject all other inputs.
 
-For example, ID 1 could map to "/login.asp" and ID 2 could map to "http://www.example.com/". Features such as the ESAPI AccessReferenceMap provide this capability.
+For example, ID 1 could map to '/login.asp' and ID 2 could map to 'http://www.example.com/'. Features such as the ESAPI AccessReferenceMap provide this capability.
 
 Understand all the potential areas where untrusted inputs can enter your software: parameters or arguments, cookies, anything read from the network, environment variables, reverse DNS lookups, query results, request headers, URL components, e-mail, files, databases, and any external systems that provide data to the application. Remember that such inputs may be obtained indirectly through API calls.
 
-Many open redirect problems occur because the programmer assumed that certain inputs could not be modified, such as cookies and hidden form fields.
-
-### References
-
-* http://projects.webappsec.org/URL-Redirector-Abuse
-* http://cwe.mitre.org/data/definitions/601.html
-
-### CWE: [601](https://cwe.mitre.org/data/definitions/601.html)
-
-### WASC:  38
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Many open redirect problems occur because the programmer assumed that certain inputs could not be modified, such as cookies and hidden form fields."
+references:
+   - http://projects.webappsec.org/URL-Redirector-Abuse
+   - http://cwe.mitre.org/data/definitions/601.html
+cwe: 601
+wasc: 38
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+URL redirectors represent common functionality employed by web sites to forward an incoming request to an alternate resource. This can be done for a variety of reasons and is often done to allow resources to be moved within the directory structure and to avoid breaking functionality for users that request the resource at its previous location. URL redirectors may also be used to implement load balancing, leveraging abbreviated URLs or recording outgoing links. It is this last implementation which is often used in phishing attacks as described in the example below. URL redirectors do not necessarily represent a direct security vulnerability but can be abused by attackers trying to social engineer victims into believing that they are navigating to a site other than the true destination.

--- a/site/content/docs/alerts/3.md
+++ b/site/content/docs/alerts/3.md
@@ -1,37 +1,19 @@
 ---
 title: "Session ID in URL Rewrite"
 alertid: 3
+alertindex: 300
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "For secure content, put session ID in a cookie. To be even more secure consider using a combination of cookie and URL rewrite."
+references:
+   - http://seclists.org/lists/webappsec/2002/Oct-Dec/0111.html
+cwe: 200
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Session ID in URL Rewrite
-
-### Type: Passive Scan Rule
-
-### Risk: Medium
-
-### Description
-
 URL rewrite is used to track user session ID. The session ID may be disclosed via cross-site referer header. In addition, the session ID might be stored in browser history or server logs.
-
-### Solution
-
-For secure content, put session ID in a cookie. To be even more secure consider using a combination of cookie and URL rewrite.
-
-### References
-
-* http://seclists.org/lists/webappsec/2002/Oct-Dec/0111.html
-
-### CWE: [200](https://cwe.mitre.org/data/definitions/200.html)
-
-### WASC:  13
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/30001.md
+++ b/site/content/docs/alerts/30001.md
@@ -1,37 +1,19 @@
 ---
 title: "Buffer Overflow"
 alertid: 30001
+alertindex: 3000100
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Rewrite the background program using proper return length checking.  This will require a recompile of the background executable."
+references:
+   - https://owasp.org/www-community/attacks/Buffer_overflow_attack
+cwe: 120
+wasc: 7
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Buffer Overflow
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 Buffer overflow errors are characterized by the overwriting of memory spaces of the background web process, which should have never been modified intentionally or unintentionally. Overwriting values of the IP (Instruction Pointer), BP (Base Pointer) and other registers causes exceptions, segmentation faults, and other process errors to occur. Usually these errors end execution of the application in an unexpected way. 
-
-### Solution
-
-Rewrite the background program using proper return length checking.  This will require a recompile of the background executable.
-
-### References
-
-* https://owasp.org/www-community/attacks/Buffer_overflow_attack
-
-### CWE: [120](https://cwe.mitre.org/data/definitions/120.html)
-
-### WASC:  7
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/30002.md
+++ b/site/content/docs/alerts/30002.md
@@ -1,37 +1,19 @@
 ---
 title: "Format String Error"
 alertid: 30002
+alertindex: 3000200
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Rewrite the background program using proper deletion of bad character strings.  This will require a recompile of the background executable."
+references:
+   - https://owasp.org/www-community/attacks/Format_string_attack
+cwe: 134
+wasc: 6
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Format String Error
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 A Format String error occurs when the submitted data of an input string is evaluated as a command by the application. 
-
-### Solution
-
-Rewrite the background program using proper deletion of bad character strings.  This will require a recompile of the background executable.
-
-### References
-
-* https://owasp.org/www-community/attacks/Format_string_attack
-
-### CWE: [134](https://cwe.mitre.org/data/definitions/134.html)
-
-### WASC:  6
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/30003.md
+++ b/site/content/docs/alerts/30003.md
@@ -1,37 +1,19 @@
 ---
 title: "Integer Overflow Error"
 alertid: 30003
+alertindex: 3000300
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Rewrite the background program using proper checking of the size of integer being input to prevent overflows and divide by 0 errors.  This will require a recompile of the background executable."
+references:
+   - http://projects.webappsec.org/w/page/13246946/Integer%20Overflows
+cwe: 190
+wasc: 3
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Integer Overflow Error
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 An integer overflow condition exists when an integer, which has not been properly checked from the input stream is used within a compiled program. 
-
-### Solution
-
-Rewrite the background program using proper checking of the size of integer being input to prevent overflows and divide by 0 errors.  This will require a recompile of the background executable.
-
-### References
-
-* http://projects.webappsec.org/w/page/13246946/Integer%20Overflows
-
-### CWE: [190](https://cwe.mitre.org/data/definitions/190.html)
-
-### WASC:  3
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40003.md
+++ b/site/content/docs/alerts/40003.md
@@ -1,39 +1,21 @@
 ---
 title: "CRLF Injection"
 alertid: 40003
+alertindex: 4000300
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Type check the submitted parameter carefully.  Do not allow CRLF to be injected by filtering CRLF."
+references:
+   - http://www.watchfire.com/resources/HTTPResponseSplitting.pdf
+   - http://webappfirewall.com/lib/crlf-injection.txtnull
+   - http://www.securityfocus.com/bid/9804
+cwe: 113
+wasc: 25
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: CRLF Injection
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 Cookie can be set via CRLF injection.  It may also be possible to set arbitrary HTTP response headers. In addition, by carefully crafting the injected response using cross-site script, cache poisoning vulnerability may also exist.
-
-### Solution
-
-Type check the submitted parameter carefully.  Do not allow CRLF to be injected by filtering CRLF.
-
-### References
-
-* http://www.watchfire.com/resources/HTTPResponseSplitting.pdf
-* http://webappfirewall.com/lib/crlf-injection.txtnull
-* http://www.securityfocus.com/bid/9804
-
-### CWE: [113](https://cwe.mitre.org/data/definitions/113.html)
-
-### WASC:  25
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40008.md
+++ b/site/content/docs/alerts/40008.md
@@ -1,33 +1,17 @@
 ---
 title: "Parameter Tampering"
 alertid: 40008
+alertindex: 4000800
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Identify the cause of the error and fix it.  Do not trust client side input and enforce a tight check in the server side.  Besides, catch the exception properly.  Use a generic 500 error page for internal server error."
+cwe: 472
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Parameter Tampering
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 Parameter manipulation caused an error page or Java stack trace to be displayed.  This indicated lack of exception handling and potential areas for further exploit.
-
-### Solution
-
-Identify the cause of the error and fix it.  Do not trust client side input and enforce a tight check in the server side.  Besides, catch the exception properly.  Use a generic 500 error page for internal server error.
-
-### CWE: [472](https://cwe.mitre.org/data/definitions/472.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40009.md
+++ b/site/content/docs/alerts/40009.md
@@ -1,38 +1,20 @@
 ---
 title: "Server Side Include"
 alertid: 40009
+alertindex: 4000900
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Do not trust client side input and enforce a tight check in the server side.  Disable server side includes.
+"
+references:
+   - http://www.carleton.ca/~dmcfet/html/ssi.html
+cwe: 97
+wasc: 31
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Server Side Include
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 Certain parameters may cause Server Side Include commands to be executed.  This may allow database connection or arbitrary code to be executed.
-
-### Solution
-
-Do not trust client side input and enforce a tight check in the server side.  Disable server side includes.
-
-
-### References
-
-* http://www.carleton.ca/~dmcfet/html/ssi.html
-
-### CWE: [97](https://cwe.mitre.org/data/definitions/97.html)
-
-### WASC:  31
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40012.md
+++ b/site/content/docs/alerts/40012.md
@@ -1,31 +1,13 @@
 ---
 title: "Cross Site Scripting (Reflected)"
 alertid: 40012
+alertindex: 4001200
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Cross Site Scripting (Reflected)
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance. A browser instance can be a standard web browser client, or a browser object embedded in a software product such as the browser within WinAmp, an RSS reader, or an email client. The code itself is usually written in HTML/JavaScript, but may also extend to VBScript, ActiveX, Java, Flash, or any other browser-supported technology.
-When an attacker gets a user's browser to execute his/her code, the code will run within the security context (or zone) of the hosting web site. With this level of privilege, the code has the ability to read, modify and transmit any sensitive data accessible by the browser. A Cross-site Scripted user could have his/her account hijacked (cookie theft), their browser redirected to another location, or possibly shown fraudulent content delivered by the web site they are visiting. Cross-site Scripting attacks essentially compromise the trust relationship between a user and the web site. Applications utilizing browser object instances which load content from the file system may execute code under the local machine zone allowing for system compromise.
-
-There are three types of Cross-site Scripting attacks: non-persistent, persistent and DOM-based.
-Non-persistent attacks and DOM-based attacks require a user to either visit a specially crafted link laced with malicious code, or visit a malicious web page containing a web form, which when posted to the vulnerable site, will mount the attack. Using a malicious form will oftentimes take place when the vulnerable resource only accepts HTTP POST requests. In such a case, the form can be submitted automatically, without the victim's knowledge (e.g. by using JavaScript). Upon clicking on the malicious link or submitting the malicious form, the XSS payload will get echoed back and will get interpreted by the user's browser and execute. Another technique to send almost arbitrary requests (GET and POST) is by using an embedded client, such as Adobe Flash.
-Persistent attacks occur when the malicious code is submitted to a web site where it's stored for a period of time. Examples of an attacker's favorite targets often include message board posts, web mail messages, and web chat software. The unsuspecting user is not required to interact with any additional site/link (e.g. an attacker site or a malicious link sent via email), just simply view the web page containing the code.
-
-### Solution
-
-Phase: Architecture and Design
+risk: High
+solution: "Phase: Architecture and Design
 Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
 Examples of libraries and frameworks that make it easier to generate properly encoded output include Microsoft's Anti-XSS library, the OWASP ESAPI Encoding module, and Apache Wicket.
 
@@ -44,23 +26,23 @@ For every web page that is generated, use and specify a character encoding such 
 
 To help mitigate XSS attacks against the user's session cookie, set the session cookie to be HttpOnly. In browsers that support the HttpOnly feature (such as more recent versions of Internet Explorer and Firefox), this attribute can prevent the user's session cookie from being accessible to malicious client-side scripts that use document.cookie. This is not a complete solution, since HttpOnly is not supported by all browsers. More importantly, XMLHTTPRequest and other powerful browser technologies provide read access to HTTP headers, including the Set-Cookie header in which the HttpOnly flag is set.
 
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
 
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
 
-Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere.
+Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere."
+references:
+   - http://projects.webappsec.org/Cross-Site-Scripting
+   - http://cwe.mitre.org/data/definitions/79.html
+cwe: 79
+wasc: 8
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance. A browser instance can be a standard web browser client, or a browser object embedded in a software product such as the browser within WinAmp, an RSS reader, or an email client. The code itself is usually written in HTML/JavaScript, but may also extend to VBScript, ActiveX, Java, Flash, or any other browser-supported technology.
+When an attacker gets a user's browser to execute his/her code, the code will run within the security context (or zone) of the hosting web site. With this level of privilege, the code has the ability to read, modify and transmit any sensitive data accessible by the browser. A Cross-site Scripted user could have his/her account hijacked (cookie theft), their browser redirected to another location, or possibly shown fraudulent content delivered by the web site they are visiting. Cross-site Scripting attacks essentially compromise the trust relationship between a user and the web site. Applications utilizing browser object instances which load content from the file system may execute code under the local machine zone allowing for system compromise.
 
-### References
-
-* http://projects.webappsec.org/Cross-Site-Scripting
-* http://cwe.mitre.org/data/definitions/79.html
-
-### CWE: [79](https://cwe.mitre.org/data/definitions/79.html)
-
-### WASC:  8
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+There are three types of Cross-site Scripting attacks: non-persistent, persistent and DOM-based.
+Non-persistent attacks and DOM-based attacks require a user to either visit a specially crafted link laced with malicious code, or visit a malicious web page containing a web form, which when posted to the vulnerable site, will mount the attack. Using a malicious form will oftentimes take place when the vulnerable resource only accepts HTTP POST requests. In such a case, the form can be submitted automatically, without the victim's knowledge (e.g. by using JavaScript). Upon clicking on the malicious link or submitting the malicious form, the XSS payload will get echoed back and will get interpreted by the user's browser and execute. Another technique to send almost arbitrary requests (GET and POST) is by using an embedded client, such as Adobe Flash.
+Persistent attacks occur when the malicious code is submitted to a web site where it's stored for a period of time. Examples of an attacker's favorite targets often include message board posts, web mail messages, and web chat software. The unsuspecting user is not required to interact with any additional site/link (e.g. an attacker site or a malicious link sent via email), just simply view the web page containing the code.

--- a/site/content/docs/alerts/40013.md
+++ b/site/content/docs/alerts/40013.md
@@ -1,47 +1,29 @@
 ---
 title: "Session Fixation"
 alertid: 40013
+alertindex: 4001300
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Session Fixation
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-Session Fixation may be possible. If this issue occurs with a login URL (where the user authenticates themselves to the application), then the URL may be given by an attacker, along with a fixed session id, to a victim, in order to later assume the identity of the victim using the given session id. If the issue occurs with a non-login page, the URL and fixed session id may only be used by an attacker to track an unauthenticated user's actions. If the vulnerability occurs on a cookie field or a form field (POST parameter) rather than on a URL (GET) parameter, then some other vulnerability may also be required in order to set the cookie field on the victim's browser, to allow the vulnerability to be exploited.
-
-### Solution
-
-1) Prevent the attacker from gaining a session id by enforcing strict session ids, and by only allocating session ids upon successful authentication to the application.
+risk: High
+solution: "1) Prevent the attacker from gaining a session id by enforcing strict session ids, and by only allocating session ids upon successful authentication to the application.
 2) The server should always create a new session id upon authentication, regardless of whether a session is already in place.
 3) Bind the session id to some identificable client attribute combination, such as IP address, SSL client certificate.
 4) Sessions, when destroyed, must be destroyed on the server, as well as on the client.
 5) Implement a logout mechanism which will destroy all previous sessions for the client.
 6) Implement absolute session timeouts.
 7)Switch from a URL based to a cookie or form based session id implementation, as the latter typically require additional vulnerabilities, in order to be exploitable by an attacker
-
-
-### References
-
-* https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication
-* https://owasp.org/www-community/attacks/Session_fixation
-* http://www.acros.si/papers/session_fixation.pdf
-* http://www.technicalinfo.net/papers/WebBasedSessionManagement.html
-
-### CWE: [384](https://cwe.mitre.org/data/definitions/384.html)
-
-### WASC:  37
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+"
+references:
+   - https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication
+   - https://owasp.org/www-community/attacks/Session_fixation
+   - http://www.acros.si/papers/session_fixation.pdf
+   - http://www.technicalinfo.net/papers/WebBasedSessionManagement.html
+cwe: 384
+wasc: 37
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+Session Fixation may be possible. If this issue occurs with a login URL (where the user authenticates themselves to the application), then the URL may be given by an attacker, along with a fixed session id, to a victim, in order to later assume the identity of the victim using the given session id. If the issue occurs with a non-login page, the URL and fixed session id may only be used by an attacker to track an unauthenticated user's actions. If the vulnerability occurs on a cookie field or a form field (POST parameter) rather than on a URL (GET) parameter, then some other vulnerability may also be required in order to set the cookie field on the victim's browser, to allow the vulnerability to be exploited.

--- a/site/content/docs/alerts/40014.md
+++ b/site/content/docs/alerts/40014.md
@@ -1,31 +1,13 @@
 ---
 title: "Cross Site Scripting (Persistent)"
 alertid: 40014
+alertindex: 4001400
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Cross Site Scripting (Persistent)
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance. A browser instance can be a standard web browser client, or a browser object embedded in a software product such as the browser within WinAmp, an RSS reader, or an email client. The code itself is usually written in HTML/JavaScript, but may also extend to VBScript, ActiveX, Java, Flash, or any other browser-supported technology.
-When an attacker gets a user's browser to execute his/her code, the code will run within the security context (or zone) of the hosting web site. With this level of privilege, the code has the ability to read, modify and transmit any sensitive data accessible by the browser. A Cross-site Scripted user could have his/her account hijacked (cookie theft), their browser redirected to another location, or possibly shown fraudulent content delivered by the web site they are visiting. Cross-site Scripting attacks essentially compromise the trust relationship between a user and the web site. Applications utilizing browser object instances which load content from the file system may execute code under the local machine zone allowing for system compromise.
-
-There are three types of Cross-site Scripting attacks: non-persistent, persistent and DOM-based.
-Non-persistent attacks and DOM-based attacks require a user to either visit a specially crafted link laced with malicious code, or visit a malicious web page containing a web form, which when posted to the vulnerable site, will mount the attack. Using a malicious form will oftentimes take place when the vulnerable resource only accepts HTTP POST requests. In such a case, the form can be submitted automatically, without the victim's knowledge (e.g. by using JavaScript). Upon clicking on the malicious link or submitting the malicious form, the XSS payload will get echoed back and will get interpreted by the user's browser and execute. Another technique to send almost arbitrary requests (GET and POST) is by using an embedded client, such as Adobe Flash.
-Persistent attacks occur when the malicious code is submitted to a web site where it's stored for a period of time. Examples of an attacker's favorite targets often include message board posts, web mail messages, and web chat software. The unsuspecting user is not required to interact with any additional site/link (e.g. an attacker site or a malicious link sent via email), just simply view the web page containing the code.
-
-### Solution
-
-Phase: Architecture and Design
+risk: High
+solution: "Phase: Architecture and Design
 Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
 Examples of libraries and frameworks that make it easier to generate properly encoded output include Microsoft's Anti-XSS library, the OWASP ESAPI Encoding module, and Apache Wicket.
 
@@ -44,23 +26,23 @@ For every web page that is generated, use and specify a character encoding such 
 
 To help mitigate XSS attacks against the user's session cookie, set the session cookie to be HttpOnly. In browsers that support the HttpOnly feature (such as more recent versions of Internet Explorer and Firefox), this attribute can prevent the user's session cookie from being accessible to malicious client-side scripts that use document.cookie. This is not a complete solution, since HttpOnly is not supported by all browsers. More importantly, XMLHTTPRequest and other powerful browser technologies provide read access to HTTP headers, including the Set-Cookie header in which the HttpOnly flag is set.
 
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
 
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
 
-Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere.
+Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere."
+references:
+   - http://projects.webappsec.org/Cross-Site-Scripting
+   - http://cwe.mitre.org/data/definitions/79.html
+cwe: 79
+wasc: 8
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance. A browser instance can be a standard web browser client, or a browser object embedded in a software product such as the browser within WinAmp, an RSS reader, or an email client. The code itself is usually written in HTML/JavaScript, but may also extend to VBScript, ActiveX, Java, Flash, or any other browser-supported technology.
+When an attacker gets a user's browser to execute his/her code, the code will run within the security context (or zone) of the hosting web site. With this level of privilege, the code has the ability to read, modify and transmit any sensitive data accessible by the browser. A Cross-site Scripted user could have his/her account hijacked (cookie theft), their browser redirected to another location, or possibly shown fraudulent content delivered by the web site they are visiting. Cross-site Scripting attacks essentially compromise the trust relationship between a user and the web site. Applications utilizing browser object instances which load content from the file system may execute code under the local machine zone allowing for system compromise.
 
-### References
-
-* http://projects.webappsec.org/Cross-Site-Scripting
-* http://cwe.mitre.org/data/definitions/79.html
-
-### CWE: [79](https://cwe.mitre.org/data/definitions/79.html)
-
-### WASC:  8
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+There are three types of Cross-site Scripting attacks: non-persistent, persistent and DOM-based.
+Non-persistent attacks and DOM-based attacks require a user to either visit a specially crafted link laced with malicious code, or visit a malicious web page containing a web form, which when posted to the vulnerable site, will mount the attack. Using a malicious form will oftentimes take place when the vulnerable resource only accepts HTTP POST requests. In such a case, the form can be submitted automatically, without the victim's knowledge (e.g. by using JavaScript). Upon clicking on the malicious link or submitting the malicious form, the XSS payload will get echoed back and will get interpreted by the user's browser and execute. Another technique to send almost arbitrary requests (GET and POST) is by using an embedded client, such as Adobe Flash.
+Persistent attacks occur when the malicious code is submitted to a web site where it's stored for a period of time. Examples of an attacker's favorite targets often include message board posts, web mail messages, and web chat software. The unsuspecting user is not required to interact with any additional site/link (e.g. an attacker site or a malicious link sent via email), just simply view the web page containing the code.

--- a/site/content/docs/alerts/40015.md
+++ b/site/content/docs/alerts/40015.md
@@ -1,26 +1,13 @@
 ---
 title: "LDAP Injection"
 alertid: 40015
+alertindex: 4001500
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: LDAP Injection
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-LDAP Injection may be possible. It may be possible for an attacker to bypass authentication controls, and to view and modify arbitrary data in the LDAP directory. 
-
-### Solution
-
-Validate and/or escape all user input before using it to create an LDAP query.  In particular, the following characters (or combinations) should be blacklisted:
+risk: High
+solution: "Validate and/or escape all user input before using it to create an LDAP query.  In particular, the following characters (or combinations) should be blacklisted:
 &
 |
 !
@@ -36,25 +23,20 @@ Validate and/or escape all user input before using it to create an LDAP query.  
 ,
 +
 -
-"
+'
 '
 ;
 \
 /
 NUL character
- 
-
-### References
-
-* http://www.testingsecurity.com/how-to-test/injection-vulnerabilities/LDAP-Injection
-* https://owasp.org/www-community/attacks/LDAP_Injection
-
-### CWE: [90](https://cwe.mitre.org/data/definitions/90.html)
-
-### WASC:  29
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+ "
+references:
+   - http://www.testingsecurity.com/how-to-test/injection-vulnerabilities/LDAP-Injection
+   - https://owasp.org/www-community/attacks/LDAP_Injection
+cwe: 90
+wasc: 29
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+LDAP Injection may be possible. It may be possible for an attacker to bypass authentication controls, and to view and modify arbitrary data in the LDAP directory. 

--- a/site/content/docs/alerts/40016.md
+++ b/site/content/docs/alerts/40016.md
@@ -1,37 +1,19 @@
 ---
 title: "Cross Site Scripting (Persistent) - Prime"
 alertid: 40016
+alertindex: 4001600
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Informational
+solution: "N/A"
+references:
+   - N/A
+cwe: 79
+wasc: 8
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cross Site Scripting (Persistent) - Prime
-
-### Type: Active Scan Rule
-
-### Risk: Informational
-
-### Description
-
 N/A
-
-### Solution
-
-N/A
-
-### References
-
-* N/A
-
-### CWE: [79](https://cwe.mitre.org/data/definitions/79.html)
-
-### WASC:  8
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40017.md
+++ b/site/content/docs/alerts/40017.md
@@ -1,37 +1,19 @@
 ---
 title: "Cross Site Scripting (Persistent) - Spider"
 alertid: 40017
+alertindex: 4001700
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Informational
+solution: "N/A"
+references:
+   - N/A
+cwe: 79
+wasc: 8
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cross Site Scripting (Persistent) - Spider
-
-### Type: Active Scan Rule
-
-### Risk: Informational
-
-### Description
-
 N/A
-
-### Solution
-
-N/A
-
-### References
-
-* N/A
-
-### CWE: [79](https://cwe.mitre.org/data/definitions/79.html)
-
-### WASC:  8
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40018.md
+++ b/site/content/docs/alerts/40018.md
@@ -1,26 +1,13 @@
 ---
 title: "SQL Injection"
 alertid: 40018
+alertindex: 4001800
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: SQL Injection
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-SQL injection may be possible.
-
-### Solution
-
-Do not trust client side input, even if there is client side validation in place.  
+risk: High
+solution: "Do not trust client side input, even if there is client side validation in place.  
 In general, type check all data on the server side.
 If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'
 If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.
@@ -28,21 +15,16 @@ If database Stored Procedures can be used, use them.
 Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!
 Do not create dynamic SQL queries using simple string concatenation.
 Escape all data received from the client.
-Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.
+Apply an 'allow list' of allowed characters, or a 'deny list' of disallowed characters in user input.
 Apply the principle of least privilege by using the least privileged database user possible.
 In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.
-Grant the minimum database access that is necessary for the application.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
-
-### CWE: [89](https://cwe.mitre.org/data/definitions/89.html)
-
-### WASC:  19
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Grant the minimum database access that is necessary for the application."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+cwe: 89
+wasc: 19
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+SQL injection may be possible.

--- a/site/content/docs/alerts/40019.md
+++ b/site/content/docs/alerts/40019.md
@@ -1,26 +1,13 @@
 ---
 title: "SQL Injection - MySQL"
 alertid: 40019
+alertindex: 4001900
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: SQL Injection - MySQL
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-SQL injection may be possible
-
-### Solution
-
-Do not trust client side input, even if there is client side validation in place. 
+risk: High
+solution: "Do not trust client side input, even if there is client side validation in place. 
 In general, type check all data on the server side.
 If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'
 If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.
@@ -28,21 +15,16 @@ If database Stored Procedures can be used, use them.
 Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!
 Do not create dynamic SQL queries using simple string concatenation.
 Escape all data received from the client.
-Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.
+Apply an 'allow list' of allowed characters, or a 'deny list' of disallowed characters in user input.
 Apply the privilege of least privilege by using the least privileged database user possible.
 In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.
-Grant the minimum database access that is necessary for the application.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
-
-### CWE: [89](https://cwe.mitre.org/data/definitions/89.html)
-
-### WASC:  19
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMyqlScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMyqlScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Grant the minimum database access that is necessary for the application."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+cwe: 89
+wasc: 19
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMyqlScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+SQL injection may be possible

--- a/site/content/docs/alerts/40020.md
+++ b/site/content/docs/alerts/40020.md
@@ -1,26 +1,13 @@
 ---
 title: "SQL Injection - Hypersonic SQL"
 alertid: 40020
+alertindex: 4002000
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: SQL Injection - Hypersonic SQL
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-SQL injection may be possible
-
-### Solution
-
-Do not trust client side input, even if there is client side validation in place. 
+risk: High
+solution: "Do not trust client side input, even if there is client side validation in place. 
 In general, type check all data on the server side.
 If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'
 If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.
@@ -28,21 +15,16 @@ If database Stored Procedures can be used, use them.
 Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!
 Do not create dynamic SQL queries using simple string concatenation.
 Escape all data received from the client.
-Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.
+Apply an 'allow list' of allowed characters, or a 'deny list' of disallowed characters in user input.
 Apply the privilege of least privilege by using the least privileged database user possible.
 In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.
-Grant the minimum database access that is necessary for the application.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
-
-### CWE: [89](https://cwe.mitre.org/data/definitions/89.html)
-
-### WASC:  19
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Grant the minimum database access that is necessary for the application."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+cwe: 89
+wasc: 19
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+SQL injection may be possible

--- a/site/content/docs/alerts/40021.md
+++ b/site/content/docs/alerts/40021.md
@@ -1,26 +1,13 @@
 ---
 title: "SQL Injection - Oracle"
 alertid: 40021
+alertindex: 4002100
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: SQL Injection - Oracle
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-SQL injection may be possible
-
-### Solution
-
-Do not trust client side input, even if there is client side validation in place. 
+risk: High
+solution: "Do not trust client side input, even if there is client side validation in place. 
 In general, type check all data on the server side.
 If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'
 If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.
@@ -28,21 +15,16 @@ If database Stored Procedures can be used, use them.
 Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!
 Do not create dynamic SQL queries using simple string concatenation.
 Escape all data received from the client.
-Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.
+Apply an 'allow list' of allowed characters, or a 'deny list' of disallowed characters in user input.
 Apply the privilege of least privilege by using the least privileged database user possible.
 In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.
-Grant the minimum database access that is necessary for the application.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
-
-### CWE: [89](https://cwe.mitre.org/data/definitions/89.html)
-
-### WASC:  19
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Grant the minimum database access that is necessary for the application."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+cwe: 89
+wasc: 19
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+SQL injection may be possible

--- a/site/content/docs/alerts/40022.md
+++ b/site/content/docs/alerts/40022.md
@@ -1,26 +1,13 @@
 ---
 title: "SQL Injection - PostgreSQL"
 alertid: 40022
+alertindex: 4002200
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: SQL Injection - PostgreSQL
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-SQL injection may be possible
-
-### Solution
-
-Do not trust client side input, even if there is client side validation in place. 
+risk: High
+solution: "Do not trust client side input, even if there is client side validation in place. 
 In general, type check all data on the server side.
 If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'
 If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.
@@ -28,21 +15,16 @@ If database Stored Procedures can be used, use them.
 Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!
 Do not create dynamic SQL queries using simple string concatenation.
 Escape all data received from the client.
-Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.
+Apply an 'allow list' of allowed characters, or a 'deny list' of disallowed characters in user input.
 Apply the privilege of least privilege by using the least privileged database user possible.
 In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.
-Grant the minimum database access that is necessary for the application.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
-
-### CWE: [89](https://cwe.mitre.org/data/definitions/89.html)
-
-### WASC:  19
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Grant the minimum database access that is necessary for the application."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+cwe: 89
+wasc: 19
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+SQL injection may be possible

--- a/site/content/docs/alerts/40023.md
+++ b/site/content/docs/alerts/40023.md
@@ -1,38 +1,20 @@
 ---
 title: "Possible Username Enumeration"
 alertid: 40023
+alertindex: 4002300
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Informational
+solution: "Do not divulge details of whether a username is valid or invalid. In particular, for unsuccessful login attempts, do not differentiate between an invalid user and an invalid password in the error message, page title, page contents, HTTP headers, or redirection logic."
+references:
+   - https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.html
+   - http://sebastian-schinzel.de/_download/ifip-sec2011.pdf
+cwe: 200
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Possible Username Enumeration
-
-### Type: Active Scan Rule
-
-### Risk: Informational
-
-### Description
-
 It may be possible to enumerate usernames, based on differing HTTP responses when valid and invalid usernames are provided. This would greatly increase the probability of success of password brute-forcing attacks against the system. Note that false positives may sometimes be minimised by increasing the 'Attack Strength' Option in ZAP.  Please manually check the 'Other Info' field to confirm if this is actually an issue. 
-
-### Solution
-
-Do not divulge details of whether a username is valid or invalid. In particular, for unsuccessful login attempts, do not differentiate between an invalid user and an invalid password in the error message, page title, page contents, HTTP headers, or redirection logic.
-
-### References
-
-* https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.html
-* http://sebastian-schinzel.de/_download/ifip-sec2011.pdf
-
-### CWE: [200](https://cwe.mitre.org/data/definitions/200.html)
-
-### WASC:  13
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40024.md
+++ b/site/content/docs/alerts/40024.md
@@ -1,26 +1,13 @@
 ---
 title: "SQL Injection - SQLite"
 alertid: 40024
+alertindex: 4002400
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: SQL Injection - SQLite
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-SQL injection may be possible
-
-### Solution
-
-Do not trust client side input, even if there is client side validation in place. 
+risk: High
+solution: "Do not trust client side input, even if there is client side validation in place. 
 In general, type check all data on the server side.
 If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'
 If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.
@@ -28,21 +15,16 @@ If database Stored Procedures can be used, use them.
 Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!
 Do not create dynamic SQL queries using simple string concatenation.
 Escape all data received from the client.
-Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.
+Apply an 'allow list' of allowed characters, or a 'deny list' of disallowed characters in user input.
 Apply the privilege of least privilege by using the least privileged database user possible.
 In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.
-Grant the minimum database access that is necessary for the application.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
-
-### CWE: [89](https://cwe.mitre.org/data/definitions/89.html)
-
-### WASC:  19
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Grant the minimum database access that is necessary for the application."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+cwe: 89
+wasc: 19
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+SQL injection may be possible

--- a/site/content/docs/alerts/40025.md
+++ b/site/content/docs/alerts/40025.md
@@ -1,41 +1,23 @@
 ---
 title: "Proxy Disclosure"
 alertid: 40025
+alertindex: 4002500
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Proxy Disclosure
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
-
-
-### Solution
-
-Disable the 'TRACE' method on the proxy servers, as well as the origin web/application server.
+risk: Medium
+solution: "Disable the 'TRACE' method on the proxy servers, as well as the origin web/application server.
 Disable the 'OPTIONS' method on the proxy servers, as well as the origin web/application server, if it is not required for other purposes, such as 'CORS' (Cross Origin Resource Sharing).
 Configure the web and application servers with custom error pages, to prevent 'fingerprintable' product-specific error pages being leaked to the user in the event of HTTP errors, such as 'TRACK' requests for non-existent pages.
 Configure all proxies, application servers, and web servers to prevent disclosure of the technology and version information in the 'Server' and 'X-Powered-By' HTTP response headers.
+"
+references:
+   - https://tools.ietf.org/html/rfc7231#section-5.1.2
+cwe: 200
+wasc: 45
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
 
-
-### References
-
-* https://tools.ietf.org/html/rfc7231#section-5.1.2
-
-### CWE: [200](https://cwe.mitre.org/data/definitions/200.html)
-
-### WASC:  45
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40026.md
+++ b/site/content/docs/alerts/40026.md
@@ -1,31 +1,13 @@
 ---
 title: "Cross Site Scripting (DOM Based)"
 alertid: 40026
+alertindex: 4002600
 alerttype: "Active Scan Rule"
 alertcount: 1
-status: alpha
+status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Cross Site Scripting (DOM Based)
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance. A browser instance can be a standard web browser client, or a browser object embedded in a software product such as the browser within WinAmp, an RSS reader, or an email client. The code itself is usually written in HTML/JavaScript, but may also extend to VBScript, ActiveX, Java, Flash, or any other browser-supported technology.
-When an attacker gets a user's browser to execute his/her code, the code will run within the security context (or zone) of the hosting web site. With this level of privilege, the code has the ability to read, modify and transmit any sensitive data accessible by the browser. A Cross-site Scripted user could have his/her account hijacked (cookie theft), their browser redirected to another location, or possibly shown fraudulent content delivered by the web site they are visiting. Cross-site Scripting attacks essentially compromise the trust relationship between a user and the web site. Applications utilizing browser object instances which load content from the file system may execute code under the local machine zone allowing for system compromise.
-
-There are three types of Cross-site Scripting attacks: non-persistent, persistent and DOM-based.
-Non-persistent attacks and DOM-based attacks require a user to either visit a specially crafted link laced with malicious code, or visit a malicious web page containing a web form, which when posted to the vulnerable site, will mount the attack. Using a malicious form will oftentimes take place when the vulnerable resource only accepts HTTP POST requests. In such a case, the form can be submitted automatically, without the victim's knowledge (e.g. by using JavaScript). Upon clicking on the malicious link or submitting the malicious form, the XSS payload will get echoed back and will get interpreted by the user's browser and execute. Another technique to send almost arbitrary requests (GET and POST) is by using an embedded client, such as Adobe Flash.
-Persistent attacks occur when the malicious code is submitted to a web site where it's stored for a period of time. Examples of an attacker's favorite targets often include message board posts, web mail messages, and web chat software. The unsuspecting user is not required to interact with any additional site/link (e.g. an attacker site or a malicious link sent via email), just simply view the web page containing the code.
-
-### Solution
-
-Phase: Architecture and Design
+risk: High
+solution: "Phase: Architecture and Design
 Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
 Examples of libraries and frameworks that make it easier to generate properly encoded output include Microsoft's Anti-XSS library, the OWASP ESAPI Encoding module, and Apache Wicket.
 
@@ -44,23 +26,23 @@ For every web page that is generated, use and specify a character encoding such 
 
 To help mitigate XSS attacks against the user's session cookie, set the session cookie to be HttpOnly. In browsers that support the HttpOnly feature (such as more recent versions of Internet Explorer and Firefox), this attribute can prevent the user's session cookie from being accessible to malicious client-side scripts that use document.cookie. This is not a complete solution, since HttpOnly is not supported by all browsers. More importantly, XMLHTTPRequest and other powerful browser technologies provide read access to HTTP headers, including the Set-Cookie header in which the HttpOnly flag is set.
 
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
 
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
 
-Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere.
+Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere."
+references:
+   - http://projects.webappsec.org/Cross-Site-Scripting
+   - http://cwe.mitre.org/data/definitions/79.html
+cwe: 79
+wasc: 8
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance. A browser instance can be a standard web browser client, or a browser object embedded in a software product such as the browser within WinAmp, an RSS reader, or an email client. The code itself is usually written in HTML/JavaScript, but may also extend to VBScript, ActiveX, Java, Flash, or any other browser-supported technology.
+When an attacker gets a user's browser to execute his/her code, the code will run within the security context (or zone) of the hosting web site. With this level of privilege, the code has the ability to read, modify and transmit any sensitive data accessible by the browser. A Cross-site Scripted user could have his/her account hijacked (cookie theft), their browser redirected to another location, or possibly shown fraudulent content delivered by the web site they are visiting. Cross-site Scripting attacks essentially compromise the trust relationship between a user and the web site. Applications utilizing browser object instances which load content from the file system may execute code under the local machine zone allowing for system compromise.
 
-### References
-
-* http://projects.webappsec.org/Cross-Site-Scripting
-* http://cwe.mitre.org/data/definitions/79.html
-
-### CWE: [79](https://cwe.mitre.org/data/definitions/79.html)
-
-### WASC:  8
-
-### Code
-
- * [org/zaproxy/zap/extension/domxss/TestDomXSS.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/TestDomXSS.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+There are three types of Cross-site Scripting attacks: non-persistent, persistent and DOM-based.
+Non-persistent attacks and DOM-based attacks require a user to either visit a specially crafted link laced with malicious code, or visit a malicious web page containing a web form, which when posted to the vulnerable site, will mount the attack. Using a malicious form will oftentimes take place when the vulnerable resource only accepts HTTP POST requests. In such a case, the form can be submitted automatically, without the victim's knowledge (e.g. by using JavaScript). Upon clicking on the malicious link or submitting the malicious form, the XSS payload will get echoed back and will get interpreted by the user's browser and execute. Another technique to send almost arbitrary requests (GET and POST) is by using an embedded client, such as Adobe Flash.
+Persistent attacks occur when the malicious code is submitted to a web site where it's stored for a period of time. Examples of an attacker's favorite targets often include message board posts, web mail messages, and web chat software. The unsuspecting user is not required to interact with any additional site/link (e.g. an attacker site or a malicious link sent via email), just simply view the web page containing the code.

--- a/site/content/docs/alerts/40027.md
+++ b/site/content/docs/alerts/40027.md
@@ -1,26 +1,13 @@
 ---
 title: "SQL Injection - MsSQL"
 alertid: 40027
+alertindex: 4002700
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: SQL Injection - MsSQL
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-SQL injection may be possible
-
-### Solution
-
-Do not trust client side input, even if there is client side validation in place. 
+risk: High
+solution: "Do not trust client side input, even if there is client side validation in place. 
 In general, type check all data on the server side.
 If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'
 If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.
@@ -28,21 +15,16 @@ If database Stored Procedures can be used, use them.
 Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!
 Do not create dynamic SQL queries using simple string concatenation.
 Escape all data received from the client.
-Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.
+Apply an 'allow list' of allowed characters, or a 'deny list' of disallowed characters in user input.
 Apply the privilege of least privilege by using the least privileged database user possible.
 In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.
-Grant the minimum database access that is necessary for the application.
-
-### References
-
-* https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
-
-### CWE: [89](https://cwe.mitre.org/data/definitions/89.html)
-
-### WASC:  19
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Grant the minimum database access that is necessary for the application."
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+cwe: 89
+wasc: 19
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+SQL injection may be possible

--- a/site/content/docs/alerts/40028.md
+++ b/site/content/docs/alerts/40028.md
@@ -1,39 +1,21 @@
 ---
 title: "ELMAH Information Leak"
 alertid: 40028
+alertindex: 4002800
 alerttype: "Active Scan Rule"
 alertcount: 1
-status: beta
+status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Consider whether or not ELMAH is actually required in production, if it isn't then disable it. If it is then ensure access to it requires authentication and authorization. See also: https://elmah.github.io/a/securing-error-log-pages/"
+references:
+   - https://www.troyhunt.com/aspnet-session-hijacking-with-google/
+   - https://www.nuget.org/packages/elmah
+   - https://elmah.github.io/
+cwe: 215
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: ELMAH Information Leak
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 The Error Logging Modules and Handlers (ELMAH [elmah.axd]) HTTP Module was found to be available. This module can leak a significant amount of valuable information.
-
-### Solution
-
-Consider whether or not ELMAH is actually required in production, if it isn't then disable it. If it is then ensure access to it requires authentication and authorization. See also: https://elmah.github.io/a/securing-error-log-pages/
-
-### References
-
-* https://www.troyhunt.com/aspnet-session-hijacking-with-google/
-* https://www.nuget.org/packages/elmah
-* https://elmah.github.io/
-
-### CWE: [215](https://cwe.mitre.org/data/definitions/215.html)
-
-### WASC:  13
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/ElmahScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ElmahScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40029.md
+++ b/site/content/docs/alerts/40029.md
@@ -1,39 +1,21 @@
 ---
 title: "Trace.axd Information Leak"
 alertid: 40029
+alertindex: 4002900
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Consider whether or not Trace Viewer is actually required in production, if it isn't then disable it. If it is then ensure access to it requires authentication and authorization."
+references:
+   - https://msdn.microsoft.com/en-us/library/bb386420.aspx
+   - https://msdn.microsoft.com/en-us/library/wwh16c6c.aspx
+   - https://www.dotnetperls.com/trace
+cwe: 215
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Trace.axd Information Leak
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 The ASP.NET Trace Viewer (trace.axd) was found to be available. This component can leak a significant amount of valuable information.
-
-### Solution
-
-Consider whether or not Trace Viewer is actually required in production, if it isn't then disable it. If it is then ensure access to it requires authentication and authorization.
-
-### References
-
-* https://msdn.microsoft.com/en-us/library/bb386420.aspx
-* https://msdn.microsoft.com/en-us/library/wwh16c6c.aspx
-* https://www.dotnetperls.com/trace
-
-### CWE: [215](https://cwe.mitre.org/data/definitions/215.html)
-
-### WASC:  13
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40032.md
+++ b/site/content/docs/alerts/40032.md
@@ -1,37 +1,19 @@
 ---
 title: ".htaccess Information Leak"
 alertid: 40032
+alertindex: 4003200
 alerttype: "Active Scan Rule"
 alertcount: 1
-status: beta
+status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Ensure the .htaccess file is not accessible."
+references:
+   - http://www.htaccess-guide.com/
+cwe: 215
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HtAccessScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: .htaccess Information Leak
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 htaccess files can be used to alter the configuration of the Apache Web Server software to enable/disable additional functionality and features that the Apache Web Server software has to offer. 
-
-### Solution
-
-Ensure the .htaccess file is not accessible.
-
-### References
-
-* http://www.htaccess-guide.com/
-
-### CWE: [215](https://cwe.mitre.org/data/definitions/215.html)
-
-### WASC:  13
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/HtAccessScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HtAccessScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40033.md
+++ b/site/content/docs/alerts/40033.md
@@ -1,39 +1,21 @@
 ---
 title: "NoSQL Injection - MongoDB"
 alertid: 40033
+alertindex: 4003300
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Do not trust client side input and escape all data on the server side. 
+Avoid to use the query input directly into the where and group clauses and upgrade all drivers at the latest available version."
+references:
+   - https://arxiv.org/pdf/1506.04082.pdf
+   - https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.html
+cwe: 943
+wasc: 19
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: NoSQL Injection - MongoDB
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 MongoDB query injection may be possible.
-
-### Solution
-
-Do not trust client side input and escape all data on the server side. 
-Avoid to use the query input directly into the where and group clauses and upgrade all drivers at the latest available version.
-
-### References
-
-* https://arxiv.org/pdf/1506.04082.pdf
-* https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.html
-
-### CWE: [943](https://cwe.mitre.org/data/definitions/943.html)
-
-### WASC:  19
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40034.md
+++ b/site/content/docs/alerts/40034.md
@@ -1,38 +1,20 @@
 ---
 title: ".env Information Leak"
 alertid: 40034
+alertindex: 4003400
 alerttype: "Active Scan Rule"
 alertcount: 1
-status: alpha
+status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Ensure the .env file is not accessible."
+references:
+   - https://www.google.com/search?q=db_password+filetype%3Aenv
+   - https://mobile.twitter.com/svblxyz/status/1045013939904532482
+cwe: 215
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/EnvFileScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: .env Information Leak
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 One or more .env files seems to have been located on the server. These files often expose infrastructure or administrative account credentials, API or APP keys, or other sensitive configuration information. 
-
-### Solution
-
-Ensure the .env file is not accessible.
-
-### References
-
-* https://www.google.com/search?q=db_password+filetype%3Aenv
-* https://mobile.twitter.com/svblxyz/status/1045013939904532482
-
-### CWE: [215](https://cwe.mitre.org/data/definitions/215.html)
-
-### WASC:  13
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesAlpha/EnvFileScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/EnvFileScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40035.md
+++ b/site/content/docs/alerts/40035.md
@@ -1,37 +1,19 @@
 ---
 title: "Hidden File Finder"
 alertid: 40035
+alertindex: 4003500
 alerttype: "Active Scan Rule"
 alertcount: 1
-status: alpha
+status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Consider whether or not the component is actually required in production, if it isn't then disable it. If it is then ensure access to it requires appropriate authentication and authorization, or limit exposure to internal systems or specific source IPs, etc."
+references:
+   - https://blog.hboeck.de/archives/892-Introducing-Snallygaster-a-Tool-to-Scan-for-Secrets-on-Web-Servers.html
+cwe: 538
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Hidden File Finder
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 A sensitive file was identified as accessible or available. This may leak administrative, configuration, or credential information which can be leveraged by a malicious individual to further attack the system or conduct social engineering efforts.
-
-### Solution
-
-Consider whether or not the component is actually required in production, if it isn't then disable it. If it is then ensure access to it requires appropriate authentication and authorization, or limit exposure to internal systems or specific source IPs, etc.
-
-### References
-
-* https://blog.hboeck.de/archives/892-Introducing-Snallygaster-a-Tool-to-Scan-for-Secrets-on-Web-Servers.html
-
-### CWE: [538](https://cwe.mitre.org/data/definitions/538.html)
-
-### WASC:  13
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/40036.md
+++ b/site/content/docs/alerts/40036.md
@@ -1,0 +1,17 @@
+---
+title: "JWT Scan Rule"
+alertid: 40036
+alertindex: 4003600
+alerttype: "Active Scan Rule"
+alertcount: 1
+status: alpha
+type: alert
+risk: Medium
+solution: "See reference for further information. The solution depends on implementation details"
+references:
+   - https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.html
+code: https://github.com/SasanLabs/owasp-zap-jwt-addon/blob/master/src/main/java/org/zaproxy/zap/extension/jwt/JWTActiveScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+Scanner for finding vulnerabilities in JWT implementations.

--- a/site/content/docs/alerts/41.md
+++ b/site/content/docs/alerts/41.md
@@ -1,38 +1,20 @@
 ---
 title: "Source Code Disclosure - Git "
 alertid: 41
+alertindex: 4100
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Ensure that Git metadata files are not deployed to the web server or application server"
+references:
+   - http://projects.webappsec.org/Predictable-Resource-Location
+   - http://cwe.mitre.org/data/definitions/425.html
+cwe: 541
+wasc: 34
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Source Code Disclosure - Git 
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 The source code for the current page was disclosed by the web server
-
-### Solution
-
-Ensure that Git metadata files are not deployed to the web server or application server
-
-### References
-
-* http://projects.webappsec.org/Predictable-Resource-Location
-* http://cwe.mitre.org/data/definitions/425.html
-
-### CWE: [541](https://cwe.mitre.org/data/definitions/541.html)
-
-### WASC:  34
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/42.md
+++ b/site/content/docs/alerts/42.md
@@ -1,38 +1,20 @@
 ---
 title: "Source Code Disclosure - SVN"
 alertid: 42
+alertindex: 4200
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Ensure that SVN metadata files are not deployed to the web server or application server"
+references:
+   - http://projects.webappsec.org/Predictable-Resource-Location
+   - http://cwe.mitre.org/data/definitions/425.html
+cwe: 541
+wasc: 34
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Source Code Disclosure - SVN
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 The source code for the current page was disclosed by the web server
-
-### Solution
-
-Ensure that SVN metadata files are not deployed to the web server or application server
-
-### References
-
-* http://projects.webappsec.org/Predictable-Resource-Location
-* http://cwe.mitre.org/data/definitions/425.html
-
-### CWE: [541](https://cwe.mitre.org/data/definitions/541.html)
-
-### WASC:  34
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/43.md
+++ b/site/content/docs/alerts/43.md
@@ -1,21 +1,42 @@
 ---
 title: "Source Code Disclosure - File Inclusion"
 alertid: 43
+alertindex: 4300
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
+
+For filenames, use stringent allow lists that limit the character set to be used. If feasible, only allow a single '.' character in the filename to avoid weaknesses, and exclude directory separators such as '/'. Use an allow list of allowable file extensions.
+
+Warning: if you attempt to cleanse your data, then do so that the end result is not in the form that can be dangerous. A sanitizing mechanism can remove characters such as '.' and ';' which may be required for some exploits. An attacker can try to fool the sanitizing mechanism into 'cleaning' data into a dangerous form. Suppose the attacker injects a '.' inside a filename (e.g. 'sensi.tiveFile') and the sanitizing mechanism removes the character resulting in the valid filename, 'sensitiveFile'. If the input data are now assumed to be safe, then the file may be compromised. 
+
+Inputs should be decoded and canonicalized to the application's current internal representation before being validated. Make sure that your application does not decode the same input twice. Such errors could be used to bypass allow list schemes by introducing dangerous inputs after they have been checked.
+
+Use a built-in path canonicalization function (such as realpath() in C) that produces the canonical version of the pathname, which effectively removes '..' sequences and symbolic links.
+
+Run your code using the lowest privileges that are required to accomplish the necessary tasks. If possible, create isolated accounts with limited privileges that are only used for a single task. That way, a successful attack will not immediately give the attacker access to the rest of the software or its environment. For example, database applications rarely need to run as the database administrator, especially in day-to-day operations.
+
+When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs) to the actual filenames or URLs, and reject all other inputs.
+
+Run your code in a 'jail' or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict which files can be accessed in a particular directory or which commands can be executed by your software.
+
+OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in the Java SecurityManager allows you to specify restrictions on file operations.
+
+This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise."
+references:
+   - http://projects.webappsec.org/Path-Traversal
+   - http://cwe.mitre.org/data/definitions/22.html
+cwe: 541
+wasc: 33
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Source Code Disclosure - File Inclusion
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 The Path Traversal attack technique allows an attacker access to files, directories, and commands that potentially reside outside the web document root directory. An attacker may manipulate a URL in such a way that the web site will execute or reveal the contents of arbitrary files anywhere on the web server. Any device that exposes an HTTP-based interface is potentially vulnerable to Path Traversal.
 
 Most web sites restrict user access to a specific portion of the file-system, typically called the "web document root" or "CGI root" directory. These directories contain the files intended for user access and the executable necessary to drive web application functionality. To access files or execute commands anywhere on the file-system, Path Traversal attacks will utilize the ability of special-characters sequences.
@@ -23,42 +44,3 @@ Most web sites restrict user access to a specific portion of the file-system, ty
 The most basic Path Traversal attack uses the "../" special-character sequence to alter the resource location requested in the URL. Although most popular web servers will prevent this technique from escaping the web document root, alternate encodings of the "../" sequence may help bypass the security filters. These method variations include valid and invalid Unicode-encoding ("..%u2216" or "..%c0%af") of the forward slash character, backslash characters ("..\") on Windows-based servers, URL encoded characters "%2e%2e%2f"), and double URL encoding ("..%255c") of the backslash character.
 
 Even if the web server properly restricts Path Traversal attempts in the URL path, a web application itself may still be vulnerable due to improper handling of user-supplied input. This is a common problem of web applications that use template mechanisms or load static text from files. In variations of the attack, the original URL parameter value is substituted with the file name of one of the web application's dynamic scripts. Consequently, the results can reveal source code because the file is interpreted as text instead of an executable script. These techniques often employ additional special characters such as the dot (".") to reveal the listing of the current working directory, or "%00" NULL characters in order to bypass rudimentary file extension checks.
-
-### Solution
-
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
-
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
-
-For filenames, use stringent allow lists that limit the character set to be used. If feasible, only allow a single "." character in the filename to avoid weaknesses, and exclude directory separators such as "/". Use an allow list of allowable file extensions.
-
-Warning: if you attempt to cleanse your data, then do so that the end result is not in the form that can be dangerous. A sanitizing mechanism can remove characters such as '.' and ';' which may be required for some exploits. An attacker can try to fool the sanitizing mechanism into "cleaning" data into a dangerous form. Suppose the attacker injects a '.' inside a filename (e.g. "sensi.tiveFile") and the sanitizing mechanism removes the character resulting in the valid filename, "sensitiveFile". If the input data are now assumed to be safe, then the file may be compromised. 
-
-Inputs should be decoded and canonicalized to the application's current internal representation before being validated. Make sure that your application does not decode the same input twice. Such errors could be used to bypass allow list schemes by introducing dangerous inputs after they have been checked.
-
-Use a built-in path canonicalization function (such as realpath() in C) that produces the canonical version of the pathname, which effectively removes ".." sequences and symbolic links.
-
-Run your code using the lowest privileges that are required to accomplish the necessary tasks. If possible, create isolated accounts with limited privileges that are only used for a single task. That way, a successful attack will not immediately give the attacker access to the rest of the software or its environment. For example, database applications rarely need to run as the database administrator, especially in day-to-day operations.
-
-When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs) to the actual filenames or URLs, and reject all other inputs.
-
-Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict which files can be accessed in a particular directory or which commands can be executed by your software.
-
-OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in the Java SecurityManager allows you to specify restrictions on file operations.
-
-This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
-
-### References
-
-* http://projects.webappsec.org/Path-Traversal
-* http://cwe.mitre.org/data/definitions/22.html
-
-### CWE: [541](https://cwe.mitre.org/data/definitions/541.html)
-
-### WASC:  33
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/6.md
+++ b/site/content/docs/alerts/6.md
@@ -1,21 +1,42 @@
 ---
 title: "Path Traversal"
 alertid: 6
+alertindex: 600
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
+
+For filenames, use stringent allow lists that limit the character set to be used. If feasible, only allow a single '.' character in the filename to avoid weaknesses, and exclude directory separators such as '/'. Use an allow list of allowable file extensions.
+
+Warning: if you attempt to cleanse your data, then do so that the end result is not in the form that can be dangerous. A sanitizing mechanism can remove characters such as '.' and ';' which may be required for some exploits. An attacker can try to fool the sanitizing mechanism into 'cleaning' data into a dangerous form. Suppose the attacker injects a '.' inside a filename (e.g. 'sensi.tiveFile') and the sanitizing mechanism removes the character resulting in the valid filename, 'sensitiveFile'. If the input data are now assumed to be safe, then the file may be compromised. 
+
+Inputs should be decoded and canonicalized to the application's current internal representation before being validated. Make sure that your application does not decode the same input twice. Such errors could be used to bypass allow list schemes by introducing dangerous inputs after they have been checked.
+
+Use a built-in path canonicalization function (such as realpath() in C) that produces the canonical version of the pathname, which effectively removes '..' sequences and symbolic links.
+
+Run your code using the lowest privileges that are required to accomplish the necessary tasks. If possible, create isolated accounts with limited privileges that are only used for a single task. That way, a successful attack will not immediately give the attacker access to the rest of the software or its environment. For example, database applications rarely need to run as the database administrator, especially in day-to-day operations.
+
+When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs) to the actual filenames or URLs, and reject all other inputs.
+
+Run your code in a 'jail' or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict which files can be accessed in a particular directory or which commands can be executed by your software.
+
+OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in the Java SecurityManager allows you to specify restrictions on file operations.
+
+This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise."
+references:
+   - http://projects.webappsec.org/Path-Traversal
+   - http://cwe.mitre.org/data/definitions/22.html
+cwe: 22
+wasc: 33
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Path Traversal
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 The Path Traversal attack technique allows an attacker access to files, directories, and commands that potentially reside outside the web document root directory. An attacker may manipulate a URL in such a way that the web site will execute or reveal the contents of arbitrary files anywhere on the web server. Any device that exposes an HTTP-based interface is potentially vulnerable to Path Traversal.
 
 Most web sites restrict user access to a specific portion of the file-system, typically called the "web document root" or "CGI root" directory. These directories contain the files intended for user access and the executable necessary to drive web application functionality. To access files or execute commands anywhere on the file-system, Path Traversal attacks will utilize the ability of special-characters sequences.
@@ -23,42 +44,3 @@ Most web sites restrict user access to a specific portion of the file-system, ty
 The most basic Path Traversal attack uses the "../" special-character sequence to alter the resource location requested in the URL. Although most popular web servers will prevent this technique from escaping the web document root, alternate encodings of the "../" sequence may help bypass the security filters. These method variations include valid and invalid Unicode-encoding ("..%u2216" or "..%c0%af") of the forward slash character, backslash characters ("..\") on Windows-based servers, URL encoded characters "%2e%2e%2f"), and double URL encoding ("..%255c") of the backslash character.
 
 Even if the web server properly restricts Path Traversal attempts in the URL path, a web application itself may still be vulnerable due to improper handling of user-supplied input. This is a common problem of web applications that use template mechanisms or load static text from files. In variations of the attack, the original URL parameter value is substituted with the file name of one of the web application's dynamic scripts. Consequently, the results can reveal source code because the file is interpreted as text instead of an executable script. These techniques often employ additional special characters such as the dot (".") to reveal the listing of the current working directory, or "%00" NULL characters in order to bypass rudimentary file extension checks.
-
-### Solution
-
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
-
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
-
-For filenames, use stringent allow lists that limit the character set to be used. If feasible, only allow a single "." character in the filename to avoid weaknesses, and exclude directory separators such as "/". Use an allow list of allowable file extensions.
-
-Warning: if you attempt to cleanse your data, then do so that the end result is not in the form that can be dangerous. A sanitizing mechanism can remove characters such as '.' and ';' which may be required for some exploits. An attacker can try to fool the sanitizing mechanism into "cleaning" data into a dangerous form. Suppose the attacker injects a '.' inside a filename (e.g. "sensi.tiveFile") and the sanitizing mechanism removes the character resulting in the valid filename, "sensitiveFile". If the input data are now assumed to be safe, then the file may be compromised. 
-
-Inputs should be decoded and canonicalized to the application's current internal representation before being validated. Make sure that your application does not decode the same input twice. Such errors could be used to bypass allow list schemes by introducing dangerous inputs after they have been checked.
-
-Use a built-in path canonicalization function (such as realpath() in C) that produces the canonical version of the pathname, which effectively removes ".." sequences and symbolic links.
-
-Run your code using the lowest privileges that are required to accomplish the necessary tasks. If possible, create isolated accounts with limited privileges that are only used for a single task. That way, a successful attack will not immediately give the attacker access to the rest of the software or its environment. For example, database applications rarely need to run as the database administrator, especially in day-to-day operations.
-
-When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs) to the actual filenames or URLs, and reject all other inputs.
-
-Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict which files can be accessed in a particular directory or which commands can be executed by your software.
-
-OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in the Java SecurityManager allows you to specify restrictions on file operations.
-
-This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
-
-### References
-
-* http://projects.webappsec.org/Path-Traversal
-* http://cwe.mitre.org/data/definitions/22.html
-
-### CWE: [22](https://cwe.mitre.org/data/definitions/22.html)
-
-### WASC:  33
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/7.md
+++ b/site/content/docs/alerts/7.md
@@ -1,21 +1,44 @@
 ---
 title: "Remote File Inclusion"
 alertid: 7
+alertindex: 700
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Phase: Architecture and Design
+When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs) to the actual filenames or URLs, and reject all other inputs.
+For example, ID 1 could map to 'inbox.txt' and ID 2 could map to 'profile.txt'. Features such as the ESAPI AccessReferenceMap provide this capability.
+
+Phases: Architecture and Design; Operation
+Run your code in a 'jail' or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict which files can be accessed in a particular directory or which commands can be executed by your software.
+OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in the Java SecurityManager allows you to specify restrictions on file operations.
+This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
+Be careful to avoid CWE-243 and other weaknesses related to jails.
+For PHP, the interpreter offers restrictions such as open basedir or safe mode which can make it more difficult for an attacker to escape out of the application. Also consider Suhosin, a hardened PHP extension, which includes various options that disable some of the more dangerous PHP features.
+
+Phase: Implementation
+Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
+For filenames, use stringent allow lists that limit the character set to be used. If feasible, only allow a single '.' character in the filename to avoid weaknesses such as CWE-23, and exclude directory separators such as '/' to avoid CWE-36. Use an allow list of allowable file extensions, which will help to avoid CWE-434.
+
+Phases: Architecture and Design; Operation
+Store library, include, and utility files outside of the web document root, if possible. Otherwise, store them in a separate directory and use the web server's access control capabilities to prevent attackers from directly requesting them. One common practice is to define a fixed constant in each calling program, then check for the existence of the constant in the library/include file; if the constant does not exist, then the file was directly requested, and it can exit immediately.
+This significantly reduces the chance of an attacker being able to bypass any protection mechanisms that are in the base program but not in the include files. It will also reduce your attack surface.
+
+Phases: Architecture and Design; Implementation
+Understand all the potential areas where untrusted inputs can enter your software: parameters or arguments, cookies, anything read from the network, environment variables, reverse DNS lookups, query results, request headers, URL components, e-mail, files, databases, and any external systems that provide data to the application. Remember that such inputs may be obtained indirectly through API calls.
+Many file inclusion problems occur because the programmer assumed that certain inputs could not be modified, especially for cookies and URL components."
+references:
+   - http://projects.webappsec.org/Remote-File-Inclusion
+   - http://cwe.mitre.org/data/definitions/98.html
+cwe: 98
+wasc: 5
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Remote File Inclusion
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 Remote File Include (RFI) is an attack technique used to exploit "dynamic file include" mechanisms in web applications. When web applications take user input (URL, parameter value, etc.) and pass them into file include commands, the web application might be tricked into including remote files with malicious code.
 
 Almost all web application frameworks support file inclusion. File inclusion is mainly used for packaging common code into separate files that are later referenced by main application modules. When a web application references an include file, the code in this file may be executed implicitly or explicitly by calling specific procedures. If the choice of module to load is based on elements from the HTTP request, the web application might be vulnerable to RFI.
@@ -24,44 +47,3 @@ An attacker can use RFI for:
     * Running malicious code on clients: the attacker's malicious code can manipulate the content of the response sent to the client. The attacker can embed malicious code in the response that will be run by the client (for example, JavaScript to steal the client session cookies).
 
 PHP is particularly vulnerable to RFI attacks due to the extensive use of "file includes" in PHP programming and due to default server configurations that increase susceptibility to an RFI attack.
-
-### Solution
-
-Phase: Architecture and Design
-When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs) to the actual filenames or URLs, and reject all other inputs.
-For example, ID 1 could map to "inbox.txt" and ID 2 could map to "profile.txt". Features such as the ESAPI AccessReferenceMap provide this capability.
-
-Phases: Architecture and Design; Operation
-Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict which files can be accessed in a particular directory or which commands can be executed by your software.
-OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in the Java SecurityManager allows you to specify restrictions on file operations.
-This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
-Be careful to avoid CWE-243 and other weaknesses related to jails.
-For PHP, the interpreter offers restrictions such as open basedir or safe mode which can make it more difficult for an attacker to escape out of the application. Also consider Suhosin, a hardened PHP extension, which includes various options that disable some of the more dangerous PHP features.
-
-Phase: Implementation
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
-For filenames, use stringent allow lists that limit the character set to be used. If feasible, only allow a single "." character in the filename to avoid weaknesses such as CWE-23, and exclude directory separators such as "/" to avoid CWE-36. Use an allow list of allowable file extensions, which will help to avoid CWE-434.
-
-Phases: Architecture and Design; Operation
-Store library, include, and utility files outside of the web document root, if possible. Otherwise, store them in a separate directory and use the web server's access control capabilities to prevent attackers from directly requesting them. One common practice is to define a fixed constant in each calling program, then check for the existence of the constant in the library/include file; if the constant does not exist, then the file was directly requested, and it can exit immediately.
-This significantly reduces the chance of an attacker being able to bypass any protection mechanisms that are in the base program but not in the include files. It will also reduce your attack surface.
-
-Phases: Architecture and Design; Implementation
-Understand all the potential areas where untrusted inputs can enter your software: parameters or arguments, cookies, anything read from the network, environment variables, reverse DNS lookups, query results, request headers, URL components, e-mail, files, databases, and any external systems that provide data to the application. Remember that such inputs may be obtained indirectly through API calls.
-Many file inclusion problems occur because the programmer assumed that certain inputs could not be modified, especially for cookies and URL components.
-
-### References
-
-* http://projects.webappsec.org/Remote-File-Inclusion
-* http://cwe.mitre.org/data/definitions/98.html
-
-### CWE: [98](https://cwe.mitre.org/data/definitions/98.html)
-
-### WASC:  5
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90001.md
+++ b/site/content/docs/alerts/90001.md
@@ -1,32 +1,16 @@
 ---
 title: "Insecure JSF ViewState"
 alertid: 90001
+alertindex: 9000100
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Secure VIEWSTATE with a MAC specific to your environment"
+references:
+   - https://www.trustwave.com/spiderlabs/advisories/TWSL2010-001.txt
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Insecure JSF ViewState
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The response at the following URL contains a ViewState value that has no cryptographic protections.
-
-### Solution
-
-Secure VIEWSTATE with a MAC specific to your environment
-
-### References
-
-* https://www.trustwave.com/spiderlabs/advisories/TWSL2010-001.txt
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90002.md
+++ b/site/content/docs/alerts/90002.md
@@ -1,32 +1,16 @@
 ---
 title: "Java Serialization Object"
 alertid: 90002
+alertindex: 9000200
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Deserialization of untrusted data is inherently dangerous and should be avoided."
+references:
+   - https://www.oracle.com/technetwork/java/seccodeguide-139067.html#8
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Java Serialization Object
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Java Serialization seems to be in use. If not correctly validated, an attacker can send a specially crafted object. This can lead to a dangerous "Remote Code Execution". A magic sequence identifying JSO has been detected (Base64: rO0AB, Raw: 0xac, 0xed, 0x00, 0x05).
-
-### Solution
-
-Deserialization of untrusted data is inherently dangerous and should be avoided.
-
-### References
-
-* https://www.oracle.com/technetwork/java/seccodeguide-139067.html#8
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90003.md
+++ b/site/content/docs/alerts/90003.md
@@ -1,32 +1,16 @@
 ---
 title: "Sub Resource Integrity Attribute Missing"
 alertid: 90003
+alertindex: 9000300
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: alpha
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Provide a valid integrity attribute to the tag."
+references:
+   - https://developer.mozilla.org/en/docs/Web/Security/Subresource_Integrity
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Sub Resource Integrity Attribute Missing
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 The integrity attribute is missing on a script or link tag served by an external server. The integrity tag prevents an attacker who have gained access to this server from injecting a malicious content. 
-
-### Solution
-
-Provide a valid integrity attribute to the tag.
-
-### References
-
-* https://developer.mozilla.org/en/docs/Web/Security/Subresource_Integrity
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90011.md
+++ b/site/content/docs/alerts/90011.md
@@ -1,34 +1,18 @@
 ---
 title: "Charset Mismatch"
 alertid: 90011
+alertindex: 9001100
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Force UTF-8 for all text content in both the HTTP header and meta tags in HTML or encoding declarations in XML."
+references:
+   - http://code.google.com/p/browsersec/wiki/Part2#Character_set_handling_and_detection
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Charset Mismatch
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 This check identifies responses where the HTTP Content-Type header declares a charset different from the charset defined by the body of the HTML or XML. When there's a charset mismatch between the HTTP header and content body Web browsers can be forced into an undesirable content-sniffing mode to determine the content's correct character set.
 
 An attacker could manipulate content on the page to be interpreted in an encoding of their choice. For example, if an attacker can control content at the beginning of the page, they could inject script using UTF-7 encoded text and manipulate some browsers into interpreting that text.
-
-### Solution
-
-Force UTF-8 for all text content in both the HTTP header and meta tags in HTML or encoding declarations in XML.
-
-### References
-
-* http://code.google.com/p/browsersec/wiki/Part2#Character_set_handling_and_detection
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90017.md
+++ b/site/content/docs/alerts/90017.md
@@ -1,37 +1,19 @@
 ---
 title: "XSLT Injection"
 alertid: 90017
+alertindex: 9001700
 alerttype: "Active Scan Rule"
 alertcount: 1
-status: alpha
+status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Sanitize and analyze every user input coming from any client-side."
+references:
+   - https://www.contextis.com/blog/xslt-server-side-injection-attacks
+cwe: 91
+wasc: 23
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XsltInjectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: XSLT Injection
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
-Injection using XSL transformations may be possible, and may allow an attacker to read system information, read and write files, and/or execute arbitrary code.
-
-### Solution
-
-Sanitize and analyze every user input coming from any client-side.
-
-### References
-
-* https://www.contextis.com/blog/xslt-server-side-injection-attacks
-
-### CWE: [91](https://cwe.mitre.org/data/definitions/91.html)
-
-### WASC:  23
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesAlpha/XsltInjectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/XsltInjectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Injection using XSL transformations may be possible, and may allow an attacker to read system information, read and write files, or execute arbitrary code.

--- a/site/content/docs/alerts/90018.md
+++ b/site/content/docs/alerts/90018.md
@@ -1,26 +1,13 @@
 ---
 title: "Advanced SQL Injection"
 alertid: 90018
+alertindex: 9001800
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Advanced SQL Injection
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-A SQL injection may be possible using the attached payload
-
-### Solution
-
-Do not trust client side input, even if there is client side validation in place.
+risk: High
+solution: "Do not trust client side input, even if there is client side validation in place.
 In general, type check all data on the server side.
 If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'
 If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.
@@ -31,19 +18,14 @@ Escape all data received from the client.
 Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.
 Apply the privilege of least privilege by using the least privileged database user possible.
 In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.
-Grant the minimum database access that is necessary for the application.
-
-### References
-
-* https://www.owasp.org/index.php/Top_10_2010-A1
-* https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet
-
-### CWE: [89](https://cwe.mitre.org/data/definitions/89.html)
-
-### WASC:  19
-
-### Code
-
- * [org/zaproxy/zap/extension/sqliplugin/SQLInjectionPlugin.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionPlugin.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Grant the minimum database access that is necessary for the application."
+references:
+   - https://www.owasp.org/index.php/Top_10_2010-A1
+   - https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet
+cwe: 89
+wasc: 19
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionPlugin.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+A SQL injection may be possible using the attached payload

--- a/site/content/docs/alerts/90019.md
+++ b/site/content/docs/alerts/90019.md
@@ -1,40 +1,22 @@
 ---
 title: "Server Side Code Injection"
 alertid: 90019
+alertindex: 9001900
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Server Side Code Injection
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-A code injection may be possible including custom code that will be evaluated by the scripting engine
-
-### Solution
-
-Do not trust client side input, even if there is client side validation in place.
+risk: High
+solution: "Do not trust client side input, even if there is client side validation in place.
 In general, type check all data on the server side and escape all data received from the client.
- Avoid the use of eval() functions combined with user input data.
-
-### References
-
-* http://cwe.mitre.org/data/definitions/94.html
-* https://owasp.org/www-community/attacks/Direct_Dynamic_Code_Evaluation_Eval%20Injection
-
-### CWE: [94](https://cwe.mitre.org/data/definitions/94.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+ Avoid the use of eval() functions combined with user input data."
+references:
+   - http://cwe.mitre.org/data/definitions/94.html
+   - https://owasp.org/www-community/attacks/Direct_Dynamic_Code_Evaluation_Eval%20Injection
+cwe: 94
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+A code injection may be possible including custom code that will be evaluated by the scripting engine

--- a/site/content/docs/alerts/90020.md
+++ b/site/content/docs/alerts/90020.md
@@ -1,28 +1,15 @@
 ---
 title: "Remote OS Command Injection"
 alertid: 90020
+alertindex: 9002000
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
----
-## Name: Remote OS Command Injection
+risk: High
+solution: "If at all possible, use library calls rather than external processes to recreate the desired functionality.
 
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
-Attack technique used for unauthorized execution of operating system commands. This attack is possible when an application accepts untrusted input to build operating system commands in an insecure manner involving improper data sanitization, and/or improper calling of external programs.
-
-### Solution
-
-If at all possible, use library calls rather than external processes to recreate the desired functionality.
-
-Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict which files can be accessed in a particular directory or which commands can be executed by your software.
+Run your code in a 'jail' or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict which files can be accessed in a particular directory or which commands can be executed by your software.
 
 OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in the Java SecurityManager allows you to specify restrictions on file operations.
 This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
@@ -41,27 +28,22 @@ If available, use structured mechanisms that automatically enforce the separatio
 
 Some languages offer multiple functions that can be used to invoke commands. Where possible, identify any function that invokes a command shell using a single string, and replace it with a function that requires individual arguments. These functions typically perform appropriate quoting and filtering of arguments. For example, in C, the system() function accepts a string that contains the entire command to be executed, whereas execl(), execve(), and others require an array of strings, one for each argument. In Windows, CreateProcess() only accepts one command at a time. In Perl, if system() is provided with an array of arguments, then it will quote each of the arguments.
 
-Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+Assume all input is malicious. Use an 'accept known good' input validation strategy, i.e., use an allow list of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a deny list). However, deny lists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
 
-When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, 'boat' may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as 'red' or 'blue.'
 
 When constructing OS command strings, use stringent allow lists that limit the character set based on the expected value of the parameter in the request. This will indirectly limit the scope of an attack, but this technique is less important than proper output encoding and escaping.
 
-Note that proper output encoding, escaping, and quoting is the most effective solution for preventing OS command injection, although input validation may provide some defense-in-depth. This is because it effectively limits what will appear in output. Input validation will not always prevent OS command injection, especially if you are required to support free-form text fields that could contain arbitrary characters. For example, when invoking a mail program, you might need to allow the subject field to contain otherwise-dangerous inputs like ";" and ">" characters, which would need to be escaped or otherwise handled. In this case, stripping the character might reduce the risk of OS command injection, but it would produce incorrect behavior because the subject field would not be recorded as the user intended. This might seem to be a minor inconvenience, but it could be more important when the program relies on well-structured subject lines in order to pass messages to other components.
+Note that proper output encoding, escaping, and quoting is the most effective solution for preventing OS command injection, although input validation may provide some defense-in-depth. This is because it effectively limits what will appear in output. Input validation will not always prevent OS command injection, especially if you are required to support free-form text fields that could contain arbitrary characters. For example, when invoking a mail program, you might need to allow the subject field to contain otherwise-dangerous inputs like ';' and '>' characters, which would need to be escaped or otherwise handled. In this case, stripping the character might reduce the risk of OS command injection, but it would produce incorrect behavior because the subject field would not be recorded as the user intended. This might seem to be a minor inconvenience, but it could be more important when the program relies on well-structured subject lines in order to pass messages to other components.
 
-Even if you make a mistake in your validation (such as forgetting one out of 100 input fields), appropriate encoding is still likely to protect you from injection-based attacks. As long as it is not done in isolation, input validation is still a useful technique, since it may significantly reduce your attack surface, allow you to detect some attacks, and provide other security benefits that proper encoding does not address.
-
-### References
-
-* http://cwe.mitre.org/data/definitions/78.html
-* https://owasp.org/www-community/attacks/Command_Injection
-
-### CWE: [78](https://cwe.mitre.org/data/definitions/78.html)
-
-### WASC:  31
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z
+Even if you make a mistake in your validation (such as forgetting one out of 100 input fields), appropriate encoding is still likely to protect you from injection-based attacks. As long as it is not done in isolation, input validation is still a useful technique, since it may significantly reduce your attack surface, allow you to detect some attacks, and provide other security benefits that proper encoding does not address."
+references:
+   - http://cwe.mitre.org/data/definitions/78.html
+   - https://owasp.org/www-community/attacks/Command_Injection
+cwe: 78
+wasc: 31
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
+---
+Attack technique used for unauthorized execution of operating system commands. This attack is possible when an application accepts untrusted input to build operating system commands in an insecure manner involving improper data sanitization, and/or improper calling of external programs.

--- a/site/content/docs/alerts/90021.md
+++ b/site/content/docs/alerts/90021.md
@@ -1,42 +1,24 @@
 ---
 title: "XPath Injection"
 alertid: 90021
+alertindex: 9002100
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Use parameterized XPath queries (e.g. using XQuery). This will help ensure separation between data plane and control plane.
+
+Properly validate user input. Reject data where appropriate, filter where appropriate and escape where appropriate. Make sure input that will be used in XPath queries is safe in that context."
+references:
+   - http://projects.webappsec.org/XPath-Injection
+   - http://cwe.mitre.org/data/definitions/643.html
+cwe: 643
+wasc: 39
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: XPath Injection
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 XPath Injection is an attack technique used to exploit applications that construct XPath (XML Path Language) queries from user-supplied input to query or navigate XML documents. It can be used directly by an application to query an XML document, as part of a larger operation such as applying an XSLT transformation to an XML document, or applying an XQuery to an XML document. The syntax of XPath bears some resemblance to an SQL query, and indeed, it is possible to form SQL-like queries on an XML document using XPath.
 
 If an application uses run-time XPath query construction, embedding unsafe user input into the query, it may be possible for the attacker to inject data into the query such that the newly formed query will be parsed in a way differing from the programmer's intention.
-
-### Solution
-
-Use parameterized XPath queries (e.g. using XQuery). This will help ensure separation between data plane and control plane.
-
-Properly validate user input. Reject data where appropriate, filter where appropriate and escape where appropriate. Make sure input that will be used in XPath queries is safe in that context.
-
-### References
-
-* http://projects.webappsec.org/XPath-Injection
-* http://cwe.mitre.org/data/definitions/643.html
-
-### CWE: [643](https://cwe.mitre.org/data/definitions/643.html)
-
-### WASC:  39
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90022.md
+++ b/site/content/docs/alerts/90022.md
@@ -1,33 +1,17 @@
 ---
 title: "Application Error Disclosure"
 alertid: 90022
+alertindex: 9002200
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "Review the source code of this page. Implement custom error pages. Consider implementing a mechanism to provide a unique error reference/identifier to the client (browser) while logging the details on the server side and not exposing them to the user."
+cwe: 200
+wasc: 13
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Application Error Disclosure
-
-### Type: Passive Scan Rule
-
-### Risk: Medium
-
-### Description
-
 This page contains an error/warning message that may disclose sensitive information like the location of the file that produced the unhandled exception. This information can be used to launch further attacks against the web application. The alert could be a false positive if the error message is found inside a documentation page.
-
-### Solution
-
-Review the source code of this page. Implement custom error pages. Consider implementing a mechanism to provide a unique error reference/identifier to the client (browser) while logging the details on the server side and not exposing them to the user.
-
-### CWE: [200](https://cwe.mitre.org/data/definitions/200.html)
-
-### WASC:  13
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90023.md
+++ b/site/content/docs/alerts/90023.md
@@ -1,39 +1,20 @@
 ---
 title: "XML External Entity Attack"
 alertid: 90023
+alertindex: 9002300
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "TBA"
+references:
+   - http://projects.webappsec.org/XML-External-Entities
+cwe: 611
+wasc: 43
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: XML External Entity Attack
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 This technique takes advantage of a feature of XML to build documents dynamically at the time of processing. An XML message can either provide data explicitly or by pointing to an URI where the data exists. In the attack technique, external entities may replace the entity value with malicious data, alternate referrals or may compromise the security of the data the server/XML application has access to.
 	Attackers may also use External Entities to have the web services server download malicious code or content to the server for use in secondary or follow on attacks.
-
-### Solution
-
-TBA
-
-### References
-
-* http://projects.webappsec.org/XML-External-Entities
-* 
-
-### CWE: [611](https://cwe.mitre.org/data/definitions/611.html)
-
-### WASC:  43
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90024.md
+++ b/site/content/docs/alerts/90024.md
@@ -1,40 +1,22 @@
 ---
 title: "Generic Padding Oracle"
 alertid: 90024
+alertindex: 9002400
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Update the affected server software, or modify the scripts so that they properly validate encrypted data before attempting decryption."
+references:
+   - http://netifera.com/research/
+   - http://www.microsoft.com/technet/security/bulletin/ms10-070.mspx
+   - http://www.mono-project.com/Vulnerabilities#ASP.NET_Padding_Oracle
+   - https://bugzilla.redhat.com/show_bug.cgi?id=623799
+cwe: 209
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOracleScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Generic Padding Oracle
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 By manipulating the padding on an encrypted string, an attacker is able to generate an error message that indicates a likely 'padding oracle' vulnerability. Such a vulnerability can affect any application or framework that uses encryption improperly, such as some versions of ASP.net, Java Server Faces, and Mono. An attacker may exploit this issue to decrypt data and recover encryption keys, potentially viewing and modifying confidential data. This rule should detect the MS10-070 padding oracle vulnerability in ASP.net if CustomErrors are enabled for that.
-
-### Solution
-
-Update the affected server software, or modify the scripts so that they properly validate encrypted data before attempting decryption.
-
-### References
-
-* http://netifera.com/research/
-* http://www.microsoft.com/technet/security/bulletin/ms10-070.mspx
-* http://www.mono-project.com/Vulnerabilities#ASP.NET_Padding_Oracle
-* https://bugzilla.redhat.com/show_bug.cgi?id=623799
-
-### CWE: [209](https://cwe.mitre.org/data/definitions/209.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/PaddingOracleScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOracleScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90025.md
+++ b/site/content/docs/alerts/90025.md
@@ -1,38 +1,20 @@
 ---
 title: "Expression Language Injection"
 alertid: 90025
+alertindex: 9002500
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Perform data validation best practice against untrusted input and to ensure that output encoding is applied when data arrives on the EL layer, so that no metacharacter is found by the interpreter within the user content before evaluation. The most obvious patterns to detect include ${ and #{, but it may be possible to encode or fragment this data."
+references:
+   - https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection
+   - http://cwe.mitre.org/data/definitions/917.html
+cwe: 917
+wasc: 20
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Expression Language Injection
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 The software constructs all or part of an expression language (EL) statement in a Java Server Page (JSP) using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended EL statement before it is executed. In certain versions of Spring 3.0.5 and earlier, there was a vulnerability (CVE-2011-2730) in which Expression Language tags would be evaluated twice, which effectively exposed any application to EL injection. However, even for later versions, this weakness is still possible depending on configuration.
-
-### Solution
-
-Perform data validation best practice against untrusted input and to ensure that output encoding is applied when data arrives on the EL layer, so that no metacharacter is found by the interpreter within the user content before evaluation. The most obvious patterns to detect include ${ and #{, but it may be possible to encode or fragment this data.
-
-### References
-
-* https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection
-* http://cwe.mitre.org/data/definitions/917.html
-
-### CWE: [917](https://cwe.mitre.org/data/definitions/917.html)
-
-### WASC:  20
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90027.md
+++ b/site/content/docs/alerts/90027.md
@@ -1,38 +1,19 @@
 ---
 title: "Cookie Slack Detector"
 alertid: 90027
+alertindex: 9002700
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Informational
+solution: ""
+references:
+   - http://projects.webappsec.org/Fingerprinting
+cwe: 200
+wasc: 45
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cookie Slack Detector
-
-### Type: Active Scan Rule
-
-### Risk: Informational
-
-### Description
-
 Repeated GET requests: drop a different cookie each time, followed by normal request with all cookies to stabilize session, compare responses against original baseline GET. This can reveal areas where cookie based authentication/attributes are not actually enforced.
-
-### Solution
-
-
-
-### References
-
-* http://projects.webappsec.org/Fingerprinting
-* 
-
-### CWE: [200](https://cwe.mitre.org/data/definitions/200.html)
-
-### WASC:  45
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90028.md
+++ b/site/content/docs/alerts/90028.md
@@ -1,40 +1,21 @@
 ---
 title: "Insecure HTTP Method"
 alertid: 90028
+alertindex: 9002800
 alerttype: "Active Scan Rule"
 alertcount: 1
 status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: Medium
+solution: "TBA"
+references:
+   - http://projects.webappsec.org/Fingerprinting
+cwe: 200
+wasc: 45
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Insecure HTTP Method
-
-### Type: Active Scan Rule
-
-### Risk: Medium
-
-### Description
-
 The most common methodology for attackers is to first footprint the target's web presence and enumerate as much information as possible. With this information, the attacker may develop an accurate attack scenario, which will effectively exploit a vulnerability in the software type/version being utilized by the target host.
 
 Multi-tier fingerprinting is similar to its predecessor, TCP/IP Fingerprinting (with a scanner such as Nmap) except that it is focused on the Application Layer of the OSI model instead of the Transport Layer. The theory behind this fingerprinting is to create an accurate profile of the target's platform, web application software technology, backend database version, configurations and possibly even their network architecture/topology.
-
-### Solution
-
-TBA
-
-### References
-
-* http://projects.webappsec.org/Fingerprinting
-* 
-
-### CWE: [200](https://cwe.mitre.org/data/definitions/200.html)
-
-### WASC:  45
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90033.md
+++ b/site/content/docs/alerts/90033.md
@@ -1,34 +1,18 @@
 ---
 title: "Loosely Scoped Cookie"
 alertid: 90033
+alertindex: 9003300
 alerttype: "Passive Scan Rule"
 alertcount: 1
 status: release
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+solution: "Always scope cookies to a FQDN (Fully Qualified Domain Name)."
+references:
+   - https://tools.ietf.org/html/rfc6265#section-4.1
+   - https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.html
+   - http://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_cookies
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Loosely Scoped Cookie
-
-### Type: Passive Scan Rule
-
-
-### Description
-
 Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. www.nottrusted.com, or loosely scoped to a parent domain e.g. nottrusted.com. In the latter case, any subdomain of nottrusted.com can access the cookie. Loosely scoped cookies are common in mega-applications like google.com and live.com. Cookies set from a subdomain like app.foo.bar are transmitted only to that domain by the browser. However, cookies scoped to a parent-level domain may be transmitted to the parent, or any subdomain of the parent.
-
-### Solution
-
-Always scope cookies to a FQDN (Fully Qualified Domain Name).
-
-### References
-
-* https://tools.ietf.org/html/rfc6265#section-4.1
-* https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.html
-* http://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_cookies
-
-### Code
-
- * [org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/content/docs/alerts/90034.md
+++ b/site/content/docs/alerts/90034.md
@@ -1,34 +1,18 @@
 ---
 title: "Cloud Metadata Potentially Exposed"
 alertid: 90034
+alertindex: 9003400
 alerttype: "Active Scan Rule"
 alertcount: 1
-status: alpha
+status: beta
 type: alert
-date: 2020-08-14 11:48:43.628Z
-lastmod: 2020-08-14 11:48:43.628Z
+risk: High
+solution: "Do not trust any user data in NGINX configs. In this case it is probably the use of the $host variable which is set from the 'Host' header and can be controlled by an attacker."
+references:
+   - https://www.nginx.com/blog/trust-no-one-perils-of-trusting-user-input/
+code: https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRule.java
+date: 2020-11-02 15:05:54.417Z
+lastmod: 2020-11-02 15:05:54.417Z
 ---
-## Name: Cloud Metadata Potentially Exposed
-
-### Type: Active Scan Rule
-
-### Risk: High
-
-### Description
-
 The Cloud Metadata Attack attempts to abuse a misconfigured NGINX server in order to access the instance metadata maintained by cloud service providers such as AWS, GCP and Azure.
 All of these providers provide metadata via an internal unroutable IP address '169.254.169.254' - this can be exposed by incorrectly configured NGINX servers and accessed by using this IP address in the Host header field.
-
-### Solution
-
-Do not trust any user data in NGINX configs. In this case it is probably the use of the $host variable which is set from the 'Host' header and can be controlled by an attacker.
-
-### References
-
-* https://www.nginx.com/blog/trust-no-one-perils-of-trusting-user-input/
-
-### Code
-
- * [org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanRule.java](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanRule.java)
-
-###### Last updated: 2020-08-14 11:48:43.628Z

--- a/site/layouts/alert/list.html
+++ b/site/layouts/alert/list.html
@@ -12,13 +12,15 @@
             <TH>Id</TH>
             <TH>Alert</TH>
             <TH>Status</TH>
+            <TH>Risk</TH>
             <TH>Type</TH>
          </TR>
-         {{ range (.Pages.ByParam "alertid") }}
+         {{ range (.Pages.ByParam "alertindex") }}
          <tr>
             <td><a href="{{ .Permalink }}">{{ .Params.alertid }}</a></td>
             <td><a href="{{ .Permalink }}">{{ .Title }}</a></td>
             <td>{{ .Params.status }}</td>
+            <td>{{ .Params.risk }}</td>
             <td>{{ .Params.alerttype }}</td>
          </tr>
          </li>

--- a/site/layouts/alert/single.html
+++ b/site/layouts/alert/single.html
@@ -6,17 +6,89 @@
 </section>
 {{ $section := .Site.GetPage "section" .Section }}
 <div class="wrapper py-20" data-kind="{{ .Kind }}">
-    <div class="breadcrumbs">
+    <header class="breadcrumbs">
         <a href="/docs/">Docs</a> &gt;
         <a href="/docs/alerts/">Alerts</a>
-    </div>
-    <div class="flex">
-      <article class="pr-30 content single-post">
-          <main class="post-content">
-            {{ .Content }}
-          </main>
-      </article>
-    </div>
+    </header>
+    <main class="post-content flex pt-10 on-sm-stack">
+      <section class="col-1-3 mr-30 mb-30">
+        <table class="bordered">
+          <thead>
+            <tr>
+              <th colspan="2">
+                Details
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <strong>Alert Id</strong>
+              </td>
+              <td>{{ .Params.alertid }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>Alert Type</strong>
+              </td>
+              <td>{{ .Params.alerttype }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>Status</strong>
+              </td>
+              <td>{{ .Params.status }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>
+                  Risk
+                </td>
+              <td>{{ .Params.risk }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>CWE</strong>
+              </td>
+              <td>
+                <a href="https://cwe.mitre.org/data/definitions/{{ .Params.cwe }}.html">
+                  {{ .Params.cwe }}
+                </a>
+              </td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>WASC</strong>
+              </td>
+              <td>{{ .Params.wasc }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+      <section class="col-2-3">
+        <div data-attr="summary">
+          <h3 class="mb-10">Summary</h3>
+          {{ .Content }}
+        </div>
+        <div data-attr="solution" class="mb-20">
+          <h3 class="mb-10">Solution</h3>
+          {{ .Params.solution }}
+        </div>
+        <h3 class="mb-10">References</h3>
+        <ul data-attr="references">
+        {{ range .Params.references }}
+          <li>
+            <a href="{{ . }}">{{ . }}</a>
+          </li>
+        {{ end }}
+        </ul>
+        <h4 class="mb-10">Code</h4>
+          <a href='{{ .Params.code  }}'>
+            {{ index (split .Params.code "main/java/") 1 }}
+          </a>
+      </section>
+  </main>
 </div>
 {{ end }}
 

--- a/site/layouts/alertset/single.html
+++ b/site/layouts/alertset/single.html
@@ -1,0 +1,63 @@
+{{ define "main" }}
+<section class="bolt-header">
+    <div class="wrapper py-20">
+      <h1 class="text--white">{{ .Title }}</h1>
+  </div>
+</section>
+{{ $section := .Site.GetPage "section" .Section }}
+<div class="wrapper py-20" data-kind="{{ .Kind }}">
+    <header class="breadcrumbs">
+        <a href="/docs/">Docs</a> &gt;
+        <a href="/docs/alerts/">Alerts</a>
+    </header>
+    <main class="post-content flex pt-10 on-sm-stack">
+      <section class="col-1-3 mr-30 mb-30">
+        <table class="bordered">
+          <thead>
+            <tr>
+              <th colspan="2">
+                Details
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <strong>Scan Rule Id</strong>
+              </td>
+              <td>{{ .Params.alertid }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>Alert Type</strong>
+              </td>
+              <td>{{ .Params.alerttype }}</td>
+            </tr>
+            <tr> 
+              <td>
+                <strong>Status</strong>
+              </td>
+              <td>{{ .Params.status }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+      <section class="col-2-3">
+        <h3 class="mb-10">Alerts</h3>
+        <ul data-attr="alerts">
+        {{ range .Params.alerts }}
+          <li>
+            <a href="/docs/alerts/{{ .alertid }}">{{ .alertid }}</a> {{ .name }}
+          </li>
+        {{ end }}
+        </ul>
+        <h4 class="mb-10">Code</h4>
+          <a href='{{ .Params.code  }}'>
+            {{ index (split .Params.code "main/java/") 1 }}
+          </a>
+      </section>
+  </main>
+</div>
+{{ end }}
+

--- a/src/css/_page.scss
+++ b/src/css/_page.scss
@@ -34,6 +34,13 @@ table {
   width: 100%;
   border-collapse: collapse;
 
+  &.bordered {
+    border: solid 2px #eee;
+
+    td, th {
+      padding:4px 8px;
+    }
+  }
 }
 
 .table-fixed {
@@ -46,11 +53,12 @@ table.table-fixed h5 {
 
 th {
   border-bottom: solid 3px var(--grey-light);
-  padding: 4px;
+  padding: 4px 8px;
+  background:  var(--grey-light);
 }
 
 td {
-  padding: 4px;
+  padding: 4px 8px;
   border-bottom: solid 1px var(--grey-light);
 }
 

--- a/src/css/_spacing.scss
+++ b/src/css/_spacing.scss
@@ -1,5 +1,5 @@
 // Generate spacing for each size
-@each $size in 10 20 30 40 70  {
+@each $size in 0 10 20 30 40 70  {
   .p-#{$size} {
     padding: #{$size}px;
   }


### PR DESCRIPTION
Generate one page per example alert with a -1, -2 etc 'qualifier'.
If rules have multiple examples then they have an 'alertset' page which links to all of the 'sub' alerts.
This PR also includes @rezen's changes from #200 with minor tweeks, so the pages look much better.
I've regenerated all of the alert pages and manually updated the depreciated ones.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
