### PR TITLE
Tweak blog pages

### DIFF
--- a/src/css/pages/blog.scss
+++ b/src/css/pages/blog.scss
@@ -4,7 +4,7 @@
 }
 
 .post-meta {
-    background: var(--blue-light);
+    border: solid 1px var(--blue-border);
     padding: 20px;
 }
 


### PR DESCRIPTION
Removed the blue background around the blog summary and replaced it with a 1px blue line.
This is based on feedback that the blue background was v distracting and mde the blog harder to read.

Alt suggestions appreciated :)
Before
![Screenshot_2020-11-02 Sites Tree Modifiers](https://user-images.githubusercontent.com/1081115/97892041-6fb51300-1d27-11eb-9bd4-97695d6aa020.png)
After
![Screenshot_2020-11-02 Sites Tree Modifiers(1)](https://user-images.githubusercontent.com/1081115/97892084-7a6fa800-1d27-11eb-801e-fc0943dc9af0.png)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
