### PR TITLE
New Video page with links

### DIFF
--- a/site/content/addo-auth-workshop.md
+++ b/site/content/addo-auth-workshop.md
@@ -1,0 +1,33 @@
+---
+type: page
+title: ADDO Authentication Workshop
+layout: zap-in-ten
+links:
+  - name: '1 Introduction'
+    uuid: BAmiaxyzS3g2BCgX2vbVvV
+
+  - name: '2 Command line'
+    uuid: g97SccHH52RXnAcBYBmDGA
+
+  - name: '3 Packaged scans'
+    uuid: iT5C1onahsh3YhQi5SRnLL
+
+  - name: '4 Intro to Auth'
+    uuid: zwWm4qMRc8wD2KAgozvC5t
+
+  - name: '5 Simple Auth Bodgeit'
+    uuid: iErtsKxpwKn4m8iRoovtH9
+
+  - name: '6 Simple Auth JuiceShop'
+    uuid: igf3A8UdZ6QAGiFjEpLH86
+
+  - name: '7 Auth Scripts'
+    uuid: gYz7LxioR54i2gY9Ze7c4F
+
+  - name: '8 SSO with Juice Shop'
+    uuid: TMcBcuhyPt57sUqPcJUtpv
+
+---
+A set of ZAP authentication and automation workshops produced in conjunction with [All Day DevOps](https://www.alldaydevops.com/).
+Also available on https://www.alldaydevops.com/zap-in-ten
+

--- a/site/content/videos.md
+++ b/site/content/videos.md
@@ -1,8 +1,63 @@
 ---
 type: page
 title: Videos
-layout: zap-in-ten
-uuid: RyTy22GZV6UccW41UCghC8
+layout: group-links
+aliases:
+  - /zap-in-ten/
+groups:
+  - header: 'ZAP in Ten - A series of short videos about different ZAP features'
+    links:
+      - name: 'ZAP in Ten'
+        link: https://www.alldaydevops.com/zap-in-ten
+        desc: all of the videos on one page 
+
+      - name: 'Welcome'
+        link: https://play.sonatype.com/watch/RyTy22GZV6UccW41UCghC8
+        desc: (xx:yy)
+
+      - name: 'Resource Downloads'
+        link: https://play.sonatype.com/watch/JDyzdepHYqb2pjJSbdNzMh
+        desc: (xx:yy)
+
+      - name: 'Desktop Interface'
+        link: https://play.sonatype.com/watch/p35FK8Cri5A3EF3RBGoMAr
+        desc: (xx:yy)
+
+      - name: 'HUD Intro'
+        link: https://play.sonatype.com/watch/W5Lo3VYZUspbqRsEgXumgB
+        desc: (xx:yy)
+
+  - header: 'ADDO Workshop - Automation and Authentication'
+    links:
+      - name: '1 Introduction'
+        link: https://play.sonatype.com/watch/BAmiaxyzS3g2BCgX2vbVvV
+        desc: (xx:yy)
+
+      - name: '2 Command line'
+        link: https://play.sonatype.com/watch/g97SccHH52RXnAcBYBmDGA
+        desc: (xx:yy)
+
+      - name: '3 Packaged scans'
+        link: https://play.sonatype.com/watch/iT5C1onahsh3YhQi5SRnLL
+        desc: (xx:yy)
+
+      - name: '4 Introduction to Authentication'
+        link: https://play.sonatype.com/watch/zwWm4qMRc8wD2KAgozvC5t
+        desc: (xx:yy)
+
+      - name: '5 Simple Authentication with Bodgeit'
+        link: https://play.sonatype.com/watch/iErtsKxpwKn4m8iRoovtH9
+        desc: (xx:yy)
+
+      - name: '6 Simple Authentication with JuiceShop'
+        link: https://play.sonatype.com/watch/igf3A8UdZ6QAGiFjEpLH86
+        desc: (xx:yy)
+
+      - name: '7 Authentication Scripts'
+        link: https://play.sonatype.com/watch/gYz7LxioR54i2gY9Ze7c4F
+        desc: (xx:yy)
+
+      - name: '8 SSO with Juice Shop'
+        link: https://play.sonatype.com/watch/TMcBcuhyPt57sUqPcJUtpv
+        desc: (xx:yy)
 ---
-### ZAP in Ten: A series of short videos about different ZAP features
-#### Watch the first one below or see the full series [here](https://www.alldaydevops.com/zap-in-ten)

--- a/site/content/videos.md
+++ b/site/content/videos.md
@@ -2,62 +2,18 @@
 type: page
 title: Videos
 layout: group-links
-aliases:
-  - /zap-in-ten/
 groups:
-  - header: 'ZAP in Ten - A series of short videos about different ZAP features'
+  - header: 'Official ZAP Videos'
     links:
       - name: 'ZAP in Ten'
-        link: https://www.alldaydevops.com/zap-in-ten
-        desc: all of the videos on one page 
+        link: /zap-in-ten/
+        desc:  An ongoing series of short videos about different ZAP features produced in conjunction with All Day DevOps
 
-      - name: 'Welcome'
-        link: https://play.sonatype.com/watch/RyTy22GZV6UccW41UCghC8
-        desc: (xx:yy)
+      - name: 'ZAP Deep Dive Series'
+        link: /zap-deep-dive/
+        desc: An ongoing series of longer videos about ZAP features produced in conjunction with StackHawk
 
-      - name: 'Resource Downloads'
-        link: https://play.sonatype.com/watch/JDyzdepHYqb2pjJSbdNzMh
-        desc: (xx:yy)
-
-      - name: 'Desktop Interface'
-        link: https://play.sonatype.com/watch/p35FK8Cri5A3EF3RBGoMAr
-        desc: (xx:yy)
-
-      - name: 'HUD Intro'
-        link: https://play.sonatype.com/watch/W5Lo3VYZUspbqRsEgXumgB
-        desc: (xx:yy)
-
-  - header: 'ADDO Workshop - Automation and Authentication'
-    links:
-      - name: '1 Introduction'
-        link: https://play.sonatype.com/watch/BAmiaxyzS3g2BCgX2vbVvV
-        desc: (xx:yy)
-
-      - name: '2 Command line'
-        link: https://play.sonatype.com/watch/g97SccHH52RXnAcBYBmDGA
-        desc: (xx:yy)
-
-      - name: '3 Packaged scans'
-        link: https://play.sonatype.com/watch/iT5C1onahsh3YhQi5SRnLL
-        desc: (xx:yy)
-
-      - name: '4 Introduction to Authentication'
-        link: https://play.sonatype.com/watch/zwWm4qMRc8wD2KAgozvC5t
-        desc: (xx:yy)
-
-      - name: '5 Simple Authentication with Bodgeit'
-        link: https://play.sonatype.com/watch/iErtsKxpwKn4m8iRoovtH9
-        desc: (xx:yy)
-
-      - name: '6 Simple Authentication with JuiceShop'
-        link: https://play.sonatype.com/watch/igf3A8UdZ6QAGiFjEpLH86
-        desc: (xx:yy)
-
-      - name: '7 Authentication Scripts'
-        link: https://play.sonatype.com/watch/gYz7LxioR54i2gY9Ze7c4F
-        desc: (xx:yy)
-
-      - name: '8 SSO with Juice Shop'
-        link: https://play.sonatype.com/watch/TMcBcuhyPt57sUqPcJUtpv
-        desc: (xx:yy)
+      - name: 'ADDO ZAP Automation Workshop'
+        link: /addo-auth-workshop
+        desc: A set of ZAP workshops on automation and authentication produced in conjunction with All Day DevOps
 ---

--- a/site/content/zap-deep-dive.md
+++ b/site/content/zap-deep-dive.md
@@ -1,0 +1,26 @@
+---
+type: page
+title: ZAP Deep Dive
+layout: youtube-videos
+links:
+  - name: 'Intro to ZAP'
+    uuid: CxjHGWk4BCs
+
+  - name: 'Desktop Interface'
+    uuid: -kbY4k8eSd0
+
+  - name: 'Exploring with the spider'
+    uuid: mz2nhYpU-sw
+
+  - name: 'Exploring with the Ajax Spider'
+    uuid: EwbPPPBhM4A
+
+  - name: 'Exploring in other ways'
+    uuid: F8yOU1IrfOw
+
+  - name: 'The Sites Tree'
+    uuid: 1_flXEBzEsE
+
+---
+A series of longer videos (~20-30 mins each) about different ZAP features produced in conjunction with [StackHawk](www.stackhawk.com).
+

--- a/site/content/zap-in-ten.md
+++ b/site/content/zap-in-ten.md
@@ -1,8 +1,0 @@
----
-type: page
-title: ZAP in Ten
-layout: zap-in-ten
-uuid: RyTy22GZV6UccW41UCghC8
----
-### A series of short videos about different ZAP features
-#### Watch the first one below or see the full series [here](https://www.alldaydevops.com/zap-in-ten)

--- a/site/content/zap-in-ten.md
+++ b/site/content/zap-in-ten.md
@@ -1,0 +1,63 @@
+---
+type: page
+title: ZAP in Ten
+layout: zap-in-ten
+links:
+  - name: 'Welcome'
+    uuid: RyTy22GZV6UccW41UCghC8
+
+  - name: 'Resource Downloads'
+    uuid: JDyzdepHYqb2pjJSbdNzMh
+
+  - name: 'Desktop Interface'
+    uuid: p35FK8Cri5A3EF3RBGoMAr
+
+  - name: 'HUD Intro'
+    uuid: W5Lo3VYZUspbqRsEgXumgB
+
+  - name: 'Explore your Apps'
+    uuid: rLq2nvgbuGwVn2BX9gA8r2
+    
+  - name: 'Ajax Spider'
+    uuid: eay2rpdKHt82oC1VpfzHZx
+    
+  - name: 'Passive Scanning'
+    uuid: vDWpoYjHi7fSLYFDQPWgMF
+    
+  - name: 'Active Scanning'
+    uuid: ZcEfSihgQSzuthJi4qEeW3
+    
+  - name: 'Website and Resource Update'
+    uuid: 32UoD4hxtUBvxdaK7siFzM
+    
+  - name: 'Marketplace'
+    uuid: u5Wv6KsoozBefCuEmrFDzC
+    
+  - name: '2.9.0'
+    uuid: WRwcRM9AFPpKitybFatLiD
+    
+  - name: 'Auth - Basic and Digest'
+    uuid: ttqKANDzJCAdBUkPrsz6Td
+    
+  - name: 'Authentication - Form based'
+    uuid: ttqKANDzJCAdBUkPrsz6Td
+    
+  - name: 'Intro to Scripting'
+    uuid: 7gR4qYzUZ686wEDMBfxGdf
+    
+  - name: 'Targeted Scripts'
+    uuid: JzX1YkJqdk7BYTMHikh433
+    
+  - name: 'Proxy and HttpSender scripts'
+    uuid: 4no8EY1iB8RdnQLPFpYi2a
+    
+  - name: 'Passive Scan Scripts'
+    uuid: HfENJ3GJB3zbD6sMscDrjD
+    
+  - name: 'Active Scan Scripts'
+    uuid: aEwqErXFMTYdDDQbTgnJeA
+
+---
+A series of short videos (~10 mins each) about different ZAP features produced in conjunction with [All Day DevOps](https://www.alldaydevops.com/).
+Also available on https://www.alldaydevops.com/zap-in-ten
+

--- a/site/layouts/page/youtube-videos.html
+++ b/site/layouts/page/youtube-videos.html
@@ -1,7 +1,6 @@
 {{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
 
 {{ define "main" }}
-<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
 {{ $section := .Site.GetPage "section" .Section }}
 <section class="bolt-header">
     <div class="wrapper py-20">
@@ -17,14 +16,11 @@
       {{ with .Params }}
           {{ range .links }}
 		    <div>
-			    <img
-			      style="width: 100%; margin: auto; display: block;"
-			      class="vidyard-player-embed"
-			      src="https://play.vidyard.com/{{ .uuid }}.jpg"
-			      data-uuid="{{ .uuid }}"
-			      data-v="4"
-			      data-type="inline"
-			    />
+		     <!-- iframe width="420" height="315" src="https://www.youtube.com/embed/{{ .uuid }}"></iframe--> 
+		     <div class='embed-youtube'>
+		       <iframe src='https://www.youtube.com/embed/{{ .uuid }}' frameborder='0' allowfullscreen></iframe>
+		     </div>
+		     
 		    </div>
           {{ end }}
       {{ end }}

--- a/src/css/_layout.scss
+++ b/src/css/_layout.scss
@@ -39,6 +39,10 @@
   grid-column-gap: 60px;
 }
 
+.grid_row_gap {
+  grid-row-gap: 60px;
+}
+
 .grid__two-col {
   grid-template-columns: 1fr 1fr;
 }
@@ -126,4 +130,13 @@ $grid_widths: 2 3 4 5 6 8;
 
 .fx-g-1 {
   flex-grow: 1;
+}
+
+// c/o https://embedresponsively.com/
+.embed-youtube {
+  position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;
+} 
+
+.embed-youtube iframe, .embed-youtube object, .embed-youtube embed { 
+	position: absolute; top: 0; left: 0; width: 100%; height: 100%; 
 }


### PR DESCRIPTION
Just seeing if people find this format more useful - the first section will include more links, and the (XX:YY) is intended to be the time of each video.
![Screenshot_2020-11-18 OWASP ZAP – Videos](https://user-images.githubusercontent.com/1081115/99527756-3ae6c400-2995-11eb-97ee-de284f9dc499.png)

Thoughts?
FYI hopefully there will be a new "ZAP in Depth" video series published soon which can then be added to this page...

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
