### PR TITLE
Update Docker pages for 2.10.0

### DIFF
--- a/site/content/docs/docker/_index.md
+++ b/site/content/docs/docker/_index.md
@@ -17,7 +17,7 @@ links:
 
   - name: 'API Scan'
     link: api-scan/
-    desc: a full scan of an API defined using OpenAPI / Swagger
+    desc: a full scan of an API defined using OpenAPI / Swagger, or GraphQL (post 2.9.0)
 
   - name: 'Scan Hooks'
     link: scan-hooks/

--- a/site/content/docs/docker/api-scan.md
+++ b/site/content/docs/docker/api-scan.md
@@ -9,7 +9,7 @@ type: docker
 
 The ZAP API scan is a script that is available in the ZAP [Docker](../about/) images.
 
-It is tuned for performing scans against APIs defined by OpenAPI via either a local file or a URL.
+It is tuned for performing scans against APIs defined by OpenAPI, or GraphQL (post 2.9.0) via either a local file or a URL.
 
 It imports the definition that you specify and then runs an Active Scan against the URLs found.
 The Active Scan is tuned to APIs, so it doesn't bother looking for things like XSSs.
@@ -23,7 +23,7 @@ It also includes 2 scripts that:
 ```
 Usage: zap-api-scan.py -t <target> -f <format> [options]
     -t target         target API definition, currently only an OpenAPI URL, eg https://www.example.com/openapi.json
-    -f format         either openapi or soap
+    -f format         openapi, soap, or graphql (graphql post 2.9.0)
 Options:
     -h                print this help message
     -c config_file    config file to use to INFO, IGNORE or FAIL warnings
@@ -38,13 +38,14 @@ Options:
     -P                specify listen port
     -D                delay in seconds to wait for passive scanning 
     -i                default rules not in the config file to INFO
-    -I                do not return failure on warning
+    -I                do not return failure on warning (post 2.9.0)
     -l level          minimum level to show: PASS, IGNORE, INFO, WARN or FAIL, use with -s to hide example URLs
     -n context_file   context file which will be loaded prior to scanning the target
     -p progress_file  progress file which specifies issues that are being addressed
     -s                short output format - dont show PASSes or example URLs
     -S                safe mode this will skip the active scan and perform a baseline scan
     -T                max time in minutes to wait for ZAP to start and the passive scan to run
+    -U user           username to use for authenticated scans - must be defined in the given context file (post 2.9.0)
     -O                the hostname to override in the (remote) OpenAPI spec
     -z zap_options    ZAP command line options e.g. -z "-config aaa=bbb -config ccc=ddd"
     --hook            path to python file that define your custom hooks
@@ -134,6 +135,10 @@ Unlike the baseline configuration file the API configuration file handles both a
 For more details see the blog posts:
 * [Exploring APIs with ZAP](/blog/2017-04-03-exploring-apis-with-zap/)
 * [Scanning APIs with ZAP](/blog/2017-06-19-scanning-apis-with-zap/)
+* [Introducing the GraphQL Add-on for ZAP](/blog/2020-08-28-introducing-the-graphql-add-on-for-zap/)
 
 ### Scan Hooks
 This script supports [scan hooks](../scan-hooks/) which allow you to override or modify behaviour of the script components instead of having to write a new script.
+
+### Source Code
+The source code for this script is in [https://github.com/zaproxy/zaproxy/tree/develop/docker](https://github.com/zaproxy/zaproxy/tree/develop/docker).

--- a/site/content/docs/docker/baseline-scan.md
+++ b/site/content/docs/docker/baseline-scan.md
@@ -42,6 +42,7 @@ Options:
     -p progress_file  progress file which specifies issues that are being addressed
     -s                short output format - dont show PASSes or example URLs
     -T                max time in minutes to wait for ZAP to start and the passive scan to run
+    -U user           username to use for authenticated scans - must be defined in the given context file (post 2.9.0)
     -z zap_options    ZAP command line options e.g. -z "-config aaa=bbb -config ccc=ddd"
     --hook            path to python file that define your custom hooks
 ```
@@ -184,3 +185,6 @@ These generate a [dashboard](https://github.com/zaproxy/community-scripts/wiki/B
 
 ### Scan Hooks
 This script supports [scan hooks](../scan-hooks/) which allow you to override or modify behaviour of the script components instead of having to write a new script.
+
+### Source Code
+The source code for this script is in [https://github.com/zaproxy/zaproxy/tree/develop/docker](https://github.com/zaproxy/zaproxy/tree/develop/docker).

--- a/site/content/docs/docker/full-scan.md
+++ b/site/content/docs/docker/full-scan.md
@@ -35,13 +35,14 @@ Options:
     -P                specify listen port
     -D                delay in seconds to wait for passive scanning 
     -i                default rules not in the config file to INFO
-    -I                do not return failure on warning
+    -I                do not return failure on warning (post 2.9.0)
     -j                use the Ajax spider in addition to the traditional one
     -l level          minimum level to show: PASS, IGNORE, INFO, WARN or FAIL, use with -s to hide example URLs
     -n context_file   context file which will be loaded prior to scanning the target
     -p progress_file  progress file which specifies issues that are being addressed
     -s                short output format - dont show PASSes or example URLs
     -T                max time in minutes to wait for ZAP to start and the passive scan to run
+    -U user           username to use for authenticated scans - must be defined in the given context file (post 2.9.0)
     -z zap_options    ZAP command line options e.g. -z "-config aaa=bbb -config ccc=ddd"
     --hook            path to python file that define your custom hooks
 ```
@@ -59,3 +60,6 @@ Note that `$(pwd)` is only supported on Linux and MacOS - on Windows you will ne
 
 ### Scan Hooks
 This script supports [scan hooks](../scan-hooks/) which allow you to override or modify behaviour of the script components instead of having to write a new script.
+
+### Source Code
+The source code for this script is in [https://github.com/zaproxy/zaproxy/tree/develop/docker](https://github.com/zaproxy/zaproxy/tree/develop/docker).

--- a/site/content/docs/docker/scan-hooks.md
+++ b/site/content/docs/docker/scan-hooks.md
@@ -32,7 +32,7 @@ tests you want to run.
 #### Define your hooks in a python file `my-hooks.py`
 You define all the hooks you want to integrate with using python methods that
 correspond with the name of the hook. By default, ZAP scans will load hooks defined in
-`~/.zap_hooks.py` or you may specify the hooks location using a command line flag `--hook=my-hooks.py`. 
+`~/.zap_hooks.py`, the CWD (post 2.9.0) or you may specify the hooks location using a command line flag `--hook=my-hooks.py`. 
 
 ```python
 # vim my-hooks.py
@@ -53,6 +53,9 @@ docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable zap-baseline.py \
 ```
 
 Note that `$(pwd)` is only supported on Linux and MacOS - on Windows you will need to replace this with the full current working directory.
+
+## Example Hooks
+See https://github.com/zaproxy/community-scripts/tree/master/scan-hooks
 
 ## List of Hooks
 - `cli_opts(opts)`
@@ -76,4 +79,7 @@ Note that `$(pwd)` is only supported on Linux and MacOS - on Windows you will ne
 - `zap_import_context(zap, context_file)`
 - `zap_import_context_wrap(context_id)`
 - `zap_pre_shutdown(zap)`
+- `zap_set_scan_user(zap, username)` - post 2.9.0
+- `zap_set_scan_user_wrap(unused)` - post 2.9.0
+- `zap_tuned` - post 2.9.0
 - `pre_exit(fail_count, warn_count, pass_count)`


### PR DESCRIPTION
Most of these changes are already in the weeklies, and one of the
changes had already been added.

* Added -U user param + new scan hook calls
* Added GraphQL support
* Flagged -I as being post 2.9.0
* Added link to source folder
* Added link to example scan hooks
* Added note about docker networking

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
