### PR TITLE
Update help of add-ons removed from marketplace

### DIFF
--- a/site/content/docs/desktop/addons/vulncheck/_index.md
+++ b/site/content/docs/desktop/addons/vulncheck/_index.md
@@ -7,8 +7,9 @@ cascade:
   addon:
     id: vulncheck
     version: 2.0.0
+deprecated: true
 ---
 
 # VulnCheck
 
-Lists vulnerabilities from known databases.
+This add-on is no longer available in the marketplace, no longer being maintained.

--- a/site/content/docs/desktop/addons/wafp-extension/_index.md
+++ b/site/content/docs/desktop/addons/wafp-extension/_index.md
@@ -7,8 +7,9 @@ cascade:
   addon:
     id: cmss
     version: 3.0.0
+deprecated: true
 ---
 
 # WAFP Extension
 
-Allows to fingerprint web applications.
+This add-on is no longer available in the marketplace, no longer being maintained. Refer to [Technology Detection add-on](/docs/desktop/addons/technology-detection/) for a replacement.

--- a/site/layouts/partials/tree.html
+++ b/site/layouts/partials/tree.html
@@ -19,17 +19,22 @@
     {{ $nextDepth := add .depth 1 }}
     {{- $activeLink := $.root.Permalink }}
     {{- $className := "" }}
+    {{- $deprecated := true }}
     {{- with $.root.Site.GetPage .url }}
-        {{- $branchLink := .Permalink }}
-        {{- if in $activeLink $branchLink  }}
-            {{- $className = "tree-branch-active" -}}
-        {{ end }}
-        {{- if eq $activeLink $branchLink  }}
-            {{- $className = "tree-active tree-branch-active" -}}
-        {{- end -}}
-        <li data-depth="{{ $.depth }}" class="{{ $className }}">
-            <a href="{{ .Permalink }}">{{ .Title }}</a>
+        {{- if not .Params.deprecated }}
+            {{- $deprecated = false }}
+            {{- $branchLink := .Permalink }}
+            {{- if in $activeLink $branchLink  }}
+                {{- $className = "tree-branch-active" -}}
+            {{ end }}
+            {{- if eq $activeLink $branchLink  }}
+                {{- $className = "tree-active tree-branch-active" -}}
+            {{- end -}}
+            <li data-depth="{{ $.depth }}" class="{{ $className }}">
+                <a href="{{ .Permalink }}">{{ .Title }}</a>
+        {{- end }}
     {{- end }}
+    {{- if not $deprecated }}
         <ul class="tree-branch">
         {{- range (readDir .path) }}
             {{- if in .Name "image" }}
@@ -52,4 +57,5 @@
         {{- end }}
         </ul>
     </li>
+    {{- end }}
 {{ end }}


### PR DESCRIPTION
Mention that the VulnCheck and WAFP add-ons ons are no longer available
in the marketplace.
Do not list in the table of contents those add-ons.