### PR TITLE
Add donations redirect

### DIFF
--- a/site/content/redirects/donate.md
+++ b/site/content/redirects/donate.md
@@ -1,0 +1,6 @@
+---
+title: Donations
+layout: redirect
+url: /donate/
+redirect: https://owasp.org/donate?reponame=www-project-zap&title=OWASP+ZAP
+---


### PR DESCRIPTION
Zapbot recently tweeted about donating to the ZAP project, with a link to https://owasp.org/www-project-zap/. However, it was pointed out to me that the donate link isn't obvious on that page on mobile (IIRC, you have to use the hamburger menu).

I figured we may as well have a simple single spot to edit donation linking.

After this is merged I'll update the tweet tip to use `https://zaproxy.org/donate/`.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
