### PR TITLE
Generate help of add-ons

### DIFF
--- a/site/content/docs/desktop/addons/linux-webdrivers/_index.md
+++ b/site/content/docs/desktop/addons/linux-webdrivers/_index.md
@@ -6,7 +6,7 @@ weight: 1
 cascade:
   addon:
     id: webdriverlinux
-    version: 23.0.0
+    version: 24.0.0
 ---
 
 # Linux WebDrivers
@@ -14,7 +14,7 @@ cascade:
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 
 * Chrome - ChromeDriver 87.0.4280.20
-* Firefox - geckodriver 0.28.0
+* Firefox - geckodriver 0.29.0
 
 ## See also
 

--- a/site/content/docs/desktop/addons/macos-webdrivers/_index.md
+++ b/site/content/docs/desktop/addons/macos-webdrivers/_index.md
@@ -6,7 +6,7 @@ weight: 1
 cascade:
   addon:
     id: webdrivermacos
-    version: 22.0.0
+    version: 23.0.0
 ---
 
 # MacOS WebDrivers
@@ -14,7 +14,7 @@ cascade:
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 
 * Chrome - ChromeDriver 87.0.4280.20
-* Firefox - geckodriver 0.28.0
+* Firefox - geckodriver 0.29.0
 
 ## See also
 

--- a/site/content/docs/desktop/addons/windows-webdrivers/_index.md
+++ b/site/content/docs/desktop/addons/windows-webdrivers/_index.md
@@ -6,7 +6,7 @@ weight: 1
 cascade:
   addon:
     id: webdriverwindows
-    version: 23.0.0
+    version: 24.0.0
 ---
 
 # Windows WebDrivers
@@ -14,7 +14,7 @@ cascade:
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 
 * Chrome - ChromeDriver 87.0.4280.20
-* Firefox - geckodriver 0.28.0
+* Firefox - geckodriver 0.29.0
 
 ## See also
 


### PR DESCRIPTION
Generate the help of the following add-ons:
 - Linux WebDrivers version 24;
 - MacOS WebDrivers version 23;
 - Windows WebDrivers version 24.