### PR TITLE
Evangelists Link Check Fixes

### DIFF
--- a/.github/workflows/check-evangelists-links.yml
+++ b/.github/workflows/check-evangelists-links.yml
@@ -22,4 +22,5 @@ jobs:
         run: wget https://www.zaproxy.org/evangelists/
       - name: Check Links
         # linkedin doesn't play nice, it's always status 999, likely due to robots.txt exclusion
-        run: link-checker ./index.html --external-only --http-always-get --http-status-ignore 301 302 307 --url-ignore .*linkedin.*
+        # twitter has started responding 400 on all, though manual checks seems fine
+        run: link-checker ./index.html --external-only --http-always-get --http-status-ignore 301 302 303 307 --url-ignore .*linkedin|twitter.*

--- a/site/data/evangelists.yaml
+++ b/site/data/evangelists.yaml
@@ -391,7 +391,7 @@
   has_training: Y
   notes: >
     ZAP Evangelist,Mozilla Delhi/NCR Security lead and Information Security researcher, 
-    <a href="https://reps.mozilla.org/e/webmaker-and-security-workshop-at-niit-university/" rel="nofollow">Web Security Workshop</a>
+    <a href="https://wiki.mozilla.org/Mozilla_Delhi/Events/MozAge" rel="nofollow">Web Security Workshop</a>
 
 - name: Robert Kerby
   email: beardedwanderer@zoho.com


### PR DESCRIPTION
- Fix one 404 on reps.mozilla.org.
- Add 303 to ignored statuses (youtu.be redirect).
- Add twitter to ignore patterns.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>