### PR TITLE
Generate help of add-ons

### DIFF
--- a/site/content/docs/desktop/addons/linux-webdrivers/_index.md
+++ b/site/content/docs/desktop/addons/linux-webdrivers/_index.md
@@ -6,14 +6,14 @@ weight: 1
 cascade:
   addon:
     id: webdriverlinux
-    version: 24.0.0
+    version: 25.0.0
 ---
 
 # Linux WebDrivers
 
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 
-* Chrome - ChromeDriver 87.0.4280.20
+* Chrome - ChromeDriver 88.0.4324.96
 * Firefox - geckodriver 0.29.0
 
 ## See also

--- a/site/content/docs/desktop/addons/macos-webdrivers/_index.md
+++ b/site/content/docs/desktop/addons/macos-webdrivers/_index.md
@@ -6,14 +6,14 @@ weight: 1
 cascade:
   addon:
     id: webdrivermacos
-    version: 23.0.0
+    version: 24.0.0
 ---
 
 # MacOS WebDrivers
 
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 
-* Chrome - ChromeDriver 87.0.4280.20
+* Chrome - ChromeDriver 88.0.4324.96
 * Firefox - geckodriver 0.29.0
 
 ## See also

--- a/site/content/docs/desktop/addons/windows-webdrivers/_index.md
+++ b/site/content/docs/desktop/addons/windows-webdrivers/_index.md
@@ -6,14 +6,14 @@ weight: 1
 cascade:
   addon:
     id: webdriverwindows
-    version: 24.0.0
+    version: 25.0.0
 ---
 
 # Windows WebDrivers
 
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 
-* Chrome - ChromeDriver 87.0.4280.20
+* Chrome - ChromeDriver 88.0.4324.96
 * Firefox - geckodriver 0.29.0
 
 ## See also


### PR DESCRIPTION
Generate the help of the following add-ons:
 - Linux WebDrivers version 25;
 - MacOS WebDrivers version 24;
 - Windows WebDrivers version 25.