### PR TITLE
Start nginx server for CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: sudo apt-get update && sudo apt-get install -y nginx
+      - run: sudo apt-get update && sudo apt-get install -y nginx && sudo systemctl start nginx
       
       - name: Install node.js 10.x
         uses: actions/setup-node@v1


### PR DESCRIPTION
Change test workflow to start nginx, no longer running by default.