### PR TITLE
Blog title in blue bar

### DIFF
--- a/site/layouts/post/single.html
+++ b/site/layouts/post/single.html
@@ -1,5 +1,11 @@
 {{ define "main" }}
 {{ $section := .Site.GetPage "section" .Section }}
+<section class="bolt-header">
+  <div class="wrapper py-20">
+    <h1 class="text--white">{{ .Title }}</h1>
+  </div>
+</section>
+
 <div class="wrapper py-70" data-kind="{{ .Kind }}">
     <div class="flex latest-versions">
       <article class="col-2-3 pr-30 content single-post">
@@ -7,7 +13,6 @@
               <a href="/blog/">The ZAP Blog</a>
           </div>
 
-          <h1 class="post-title">{{ .Title }}</h1>
           <main class="post-content">
             <section class="p-10 bg--blue-lightest mb-10 mt-10 smaller-text text--blue-dark">
               Posted <span class="post-date">{{ .Date.Format "Monday January 2, 2006" }}</span>


### PR DESCRIPTION
This makes the blog posts consistant with most of the other website pages (not the home page of API pages;)

Before:
![Screenshot_2021-02-05 Run ZAP without Java using Docker and Webswing](https://user-images.githubusercontent.com/1081115/107067385-1ef60000-67d7-11eb-8c66-884a383458ec.png)


After:
![Screenshot_2021-02-05 Run ZAP without Java using Docker and Webswing(1)](https://user-images.githubusercontent.com/1081115/107067406-25847780-67d7-11eb-97a7-e4cd95f0eb90.png)


Signed-off-by: Simon Bennetts <psiinon@gmail.com>
