### PR TITLE
Update Desktop Guide Layouts for Smaller Screens

### DIFF
--- a/site/layouts/userguide/list.html
+++ b/site/layouts/userguide/list.html
@@ -1,12 +1,12 @@
 {{ define "main" }}
   <div class="wrapper py-30">
       <div class="flex latest-versions">
-          <div class="col-1-4">
+          <div class="col-1-4 on-sm-full">
               {{ block "sidebar" . }}
                 {{ partial "tree" (dict "root" . "dir" "/content/docs/desktop/")  }}
               {{end}}
             </div>
-        <div class="col-3-4 pl-30 pb-30 guide-content">
+        <div class="col-3-4 on-sm-full p-30 guide-content">
           {{ partial "crumbs" . }}
           {{ .Content }}
         </div>

--- a/site/layouts/userguide/single.html
+++ b/site/layouts/userguide/single.html
@@ -1,16 +1,15 @@
 {{ define "main" }}
   <div class="wrapper py-30">
       <div class="flex latest-versions">
-          <div class="col-1-4">
+          <div class="col-1-4 on-sm-full">
               {{ block "sidebar" . }}
                 {{ partial "tree" (dict "root" . "dir" "/content/docs/desktop/")  }}
               {{end}}
             </div>
-        <div class="col-3-4 pl-30 pb-30 guide-content">
+        <div class="col-3-4 on-sm-full p-30 guide-content">
           {{ partial "crumbs" . }}
           {{ .Content }}
         </div>
-        
       </div>
   </div>
 {{ end }}

--- a/src/css/components/_tree.scss
+++ b/src/css/components/_tree.scss
@@ -17,6 +17,25 @@
     ul {
       padding: 0 0 0 16px;
     }
+
+    @media (max-width:650px) {
+      max-height: 300px;
+      border-radius: var(--radius);
+      border: solid 4px #eee;
+      overflow: auto;
+      margin-bottom: 16px;
+
+      input[name="filter"] {
+        position: -webkit-sticky; /* Safari */
+        position: sticky;
+        width: 100%;
+        top: 0;
+      }
+
+      ul {
+        padding: 0 0 0 30px;
+      }
+    }
   }
   
 .is-filtering {


### PR DESCRIPTION
**- Description for the changelog**
As discussed last week, update desktop guide layouts for smaller screens.

**- Screenshots**
Before and After
<details><summary>Comparison 1 (Phone)</summary><img src="https://user-images.githubusercontent.com/16446369/107545840-bd2c0080-6bf1-11eb-8295-719c7744194e.png" width=500px></details>
<details><summary>Comparison 2 (Phone)</summary>
<img src="https://user-images.githubusercontent.com/16446369/107546652-9d490c80-6bf2-11eb-9875-2913f11cf56f.png" width=500px></details>
<details><summary>Animated GIF, Scrolling (Phone)</summary>
<img src="https://user-images.githubusercontent.com/16446369/107550326-e602c480-6bf6-11eb-909f-df8a9054cd17.gif" width=500px></details>
<details><summary>Comparison 3 (Desktop)</summary>
<img src="https://user-images.githubusercontent.com/16446369/107550927-a7213e80-6bf7-11eb-993b-9023ab713c89.png" width=500px></details>




Signed-off-by: ricekot <ricekot@gmail.com>
