### PR TITLE
Update Slack Invite redirect

### DIFF
--- a/site/content/redirects/slack/invite.md
+++ b/site/content/redirects/slack/invite.md
@@ -2,5 +2,5 @@
 title: Slack Invite
 layout: redirect
 url: /slack/invite
-redirect: https://owasp-slack.herokuapp.com/
+redirect: https://owasp.org/slack/invite
 ---


### PR DESCRIPTION
Per latest [foundation](https://github.com/OWASP/owasp.github.io) changes:
- Use https://owasp.org/slack/invite
