### PR TITLE
Generate help of add-ons

### DIFF
--- a/site/content/docs/desktop/addons/graphql-support/_index.md
+++ b/site/content/docs/desktop/addons/graphql-support/_index.md
@@ -6,7 +6,7 @@ weight: 1
 cascade:
   addon:
     id: graphql
-    version: 0.2.0
+    version: 0.3.0
 ---
 
 # GraphQL Support
@@ -71,7 +71,8 @@ The definitions will be imported synchronously and any warnings will be displaye
 
 ## See also
 
-|   |                                                                  |                                                |
-|---|------------------------------------------------------------------|------------------------------------------------|
-|   | [GraphQL Options](/docs/desktop/addons/graphql-support/options/) | for information about the optional parameters. |
-|   | [GraphQL Script](/docs/desktop/addons/graphql-support/script/)   | for information about the bundled script.      |
+|   |                                                                        |                                                         |
+|---|------------------------------------------------------------------------|---------------------------------------------------------|
+|   | [GraphQL Options](/docs/desktop/addons/graphql-support/options/)       | for information about the optional parameters.          |
+|   | [GraphQL Script](/docs/desktop/addons/graphql-support/script/)         | for information about the bundled script.               |
+|   | [GraphQL Automation](/docs/desktop/addons/graphql-support/automation/) | for information about the automation framework support. |

--- a/site/content/docs/desktop/addons/graphql-support/automation.md
+++ b/site/content/docs/desktop/addons/graphql-support/automation.md
@@ -1,0 +1,40 @@
+---
+# This page was generated from the add-on.
+title: GraphQL Automation Framework Support
+type: userguide
+weight: 3
+---
+
+# GraphQL Automation Framework Support
+
+This add-on supports the Automation Framework.   
+
+The add-on will import GraphQL schemas using introspection if endpoints are found while spidering. However, specifying an endpoint and (optionally) a schema file or URL is recommended if they are available.
+
+## Job: graphql
+
+The *graphql* job allows you to import GraphQL schemas locally or from a URL. It supports the following parameters:
+
+```
+  - type: graphql                      # GraphQL definition import
+    parameters:
+      endpoint:                        # String: the endpoint URL, default: null, no schema is imported
+      schemaUrl:                       # String: URL pointing to a GraphQL Schema, default: null, import using introspection on endpoint
+      schemaFile:                      # String: Local file path of a GraphQL Schema, default: null, import using schemaUrl
+      maxQueryDepth:                   # Int: The maximum query generation depth, default: 5
+      lenientMaxQueryDepthEnabled:     # Bool: Whether or not Maximum Query Depth is enforced leniently, default: true
+      maxAdditionalQueryDepth:         # Int: The maximum additional query generation depth (used if enforced leniently), default: 5
+      maxArgsDepth:                    # Int: The maximum arguments generation depth, default: 5
+      optionalArgsEnabled:             # Bool: Whether or not Optional Arguments should be specified, default: true
+      argsType:                        # Enum [inline, variables, both]: How arguments are specified, default: both 
+      querySplitType:                  # Enum [leaf, root_field, operation]: The level for which a single query is generated, default: leaf
+      requestMethod:                   # Enum [post_json, post_graphql, get]: The request method, default: post_json
+```
+
+## See also
+
+|   |                                                                  |                                                |
+|---|------------------------------------------------------------------|------------------------------------------------|
+|   | [GraphQL](/docs/desktop/addons/graphql-support/)                 | for an overview of the GraphQL add-on.         |
+|   | [GraphQL Options](/docs/desktop/addons/graphql-support/options/) | for information about the optional parameters. |
+|   | [GraphQL Script](/docs/desktop/addons/graphql-support/script/)   | for information about the bundled script.      |

--- a/site/content/docs/desktop/addons/graphql-support/options.md
+++ b/site/content/docs/desktop/addons/graphql-support/options.md
@@ -13,6 +13,14 @@ In this document, a 'Query' may refer to a GraphQL query, subscription or mutati
 
 The maximum depth of a generated query.
 
+## Lenient Maximum Query Depth
+
+If enabled, this option prevents invalid queries by allowing additional depth for fields with no leaf types. If disabled, Maximum Query Depth is enforced strictly, even if it means generating an invalid query.
+
+## Additional Query Depth
+
+The value for this option is used only if the "Lenient Maximum Query Depth" option is enabled. The maximum additional depth used to search for leaf-type fields. If a leaf type is not found, the generated query may be invalid and a message is logged.
+
 ## Maximum Arguments Depth
 
 The maximum depth of specified arguments. This is useful when a field has an input object as an argument.
@@ -47,7 +55,8 @@ The requests made to the endpoint can be of the following types:
 
 ## See also
 
-|   |                                                                |                                           |
-|---|----------------------------------------------------------------|-------------------------------------------|
-|   | [GraphQL](/docs/desktop/addons/graphql-support/)               | for an overview of the GraphQL add-on.    |
-|   | [GraphQL Script](/docs/desktop/addons/graphql-support/script/) | for information about the bundled script. |
+|   |                                                                        |                                                         |
+|---|------------------------------------------------------------------------|---------------------------------------------------------|
+|   | [GraphQL](/docs/desktop/addons/graphql-support/)                       | for an overview of the GraphQL add-on.                  |
+|   | [GraphQL Script](/docs/desktop/addons/graphql-support/script/)         | for information about the bundled script.               |
+|   | [GraphQL Automation](/docs/desktop/addons/graphql-support/automation/) | for information about the automation framework support. |

--- a/site/content/docs/desktop/addons/graphql-support/script.md
+++ b/site/content/docs/desktop/addons/graphql-support/script.md
@@ -27,7 +27,8 @@ Note that the built-in JSON Input Vector handler also works when a request is se
 
 ## See also
 
-|   |                                                                  |                                                |
-|---|------------------------------------------------------------------|------------------------------------------------|
-|   | [GraphQL](/docs/desktop/addons/graphql-support/)                 | for an overview of the GraphQL add-on.         |
-|   | [GraphQL Options](/docs/desktop/addons/graphql-support/options/) | for information about the optional parameters. |
+|   |                                                                        |                                                         |
+|---|------------------------------------------------------------------------|---------------------------------------------------------|
+|   | [GraphQL](/docs/desktop/addons/graphql-support/)                       | for an overview of the GraphQL add-on.                  |
+|   | [GraphQL Options](/docs/desktop/addons/graphql-support/options/)       | for information about the optional parameters.          |
+|   | [GraphQL Automation](/docs/desktop/addons/graphql-support/automation/) | for information about the automation framework support. |

--- a/site/content/docs/desktop/addons/soap-support/_index.md
+++ b/site/content/docs/desktop/addons/soap-support/_index.md
@@ -6,12 +6,14 @@ weight: 1
 cascade:
   addon:
     id: soap
-    version: 5.0.0
+    version: 6.0.0
 ---
 
 # SOAP Support
 
-This add-on imports and scans WSDL files containing SOAP endpoints.
+This add-on imports and scans WSDL files containing SOAP endpoints.   
+
+It also supports the [Automation Framework](/docs/desktop/addons/soap-support/automation/).
 
 ## Importing
 
@@ -22,7 +24,9 @@ The add-on will automatically detect any SOAP definitions and spider them as lon
 * Import a WSDL file from local file system
 * Import a WSDL file from a URL
 
-These operations are also available via the API.
+These operations are also available via the API.   
+
+**NOTE:** As of version 6 of this add-on, only encoded URLs are supported.
 
 ### Form Handler Add-on Support
 
@@ -35,3 +39,9 @@ The scan rules added by this add-on are:
 
 * Action Spoofing : <http://www.ws-attacks.org/index.php/SOAPAction_Spoofing>
 * XML Injection : <http://www.ws-attacks.org/index.php/XML_Injection>
+
+## Statistics
+
+This add-on maintains the following statistics:
+
+* soap.urls.added: The total number of URLs (or SOAP Actions) added from imported WSDL files.

--- a/site/content/docs/desktop/addons/soap-support/automation.md
+++ b/site/content/docs/desktop/addons/soap-support/automation.md
@@ -1,0 +1,23 @@
+---
+# This page was generated from the add-on.
+title: SOAP Automation Framework Support
+type: userguide
+weight: 1
+---
+
+# SOAP Automation Framework Support
+
+This add-on supports the Automation Framework.   
+
+The add-on will import WSDL files containing SOAP endpoints if they are found while spidering but adding them explicitly via a URL or local file is recommended if they are available.
+
+## Job: soap
+
+The soap job allows you to import WSDL files locally or from a URL.
+
+```
+  - type: soap                         # SOAP WSDL import
+    parameters:
+      wsdlFile:                        # String: Local file path of the WSDL, default: null, no definition will be imported
+      wsdlUrl:                         # String: URL pointing to the WSDL, default: null, no definition will be imported
+```


### PR DESCRIPTION
Generate the help of the following add-ons:
 - GraphQL Support version 0.3.0;
 - SOAP Support version 6.
