### PR TITLE
Fix typo in dev docs

### DIFF
--- a/site/content/docs/developer/quick-start-build.md
+++ b/site/content/docs/developer/quick-start-build.md
@@ -48,7 +48,7 @@ Note that while you have successfully got ZAP running, it doesn’t come with ma
 ## Installing ZAP Add-ons
 As the name suggests, ZAP add-ons are a way to enhance ZAP functionality. There are several add-ons that allow you to do many different things. The *zap-extensions* repository contains the source code for the add-ons maintained by the core team. So, the first thing to do is clone *zap-extensions*:
 ```bash
-git clone https://github.com/zaproxy/zap-extensions.git.
+git clone https://github.com/zaproxy/zap-extensions.git
 ```
 Then, navigate to the cloned folder and run
 ```bash


### PR DESCRIPTION
Remove dot at the end of git clone URL.

---
Reported in OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/XEDq8lOP1YQ/m/fHf0rl9zAwAJ