### PR TITLE
Tweak desktop guide layout for landscape mode

### DIFF
--- a/site/layouts/userguide/list.html
+++ b/site/layouts/userguide/list.html
@@ -1,12 +1,12 @@
 {{ define "main" }}
   <div class="wrapper py-30">
       <div class="flex latest-versions">
-          <div class="col-1-4 on-sm-full">
+          <div class="col-1-4 on-tab-full">
               {{ block "sidebar" . }}
                 {{ partial "tree" (dict "root" . "dir" "/content/docs/desktop/")  }}
               {{end}}
             </div>
-        <div class="col-3-4 on-sm-full guide-content">
+        <div class="col-3-4 on-tab-full guide-content">
           {{ partial "crumbs" . }}
           {{ .Content }}
         </div>

--- a/site/layouts/userguide/single.html
+++ b/site/layouts/userguide/single.html
@@ -1,12 +1,12 @@
 {{ define "main" }}
   <div class="wrapper py-30">
       <div class="flex latest-versions">
-          <div class="col-1-4 on-sm-full">
+          <div class="col-1-4 on-tab-full">
               {{ block "sidebar" . }}
                 {{ partial "tree" (dict "root" . "dir" "/content/docs/desktop/")  }}
               {{end}}
             </div>
-        <div class="col-3-4 on-sm-full guide-content">
+        <div class="col-3-4 on-tab-full guide-content">
           {{ partial "crumbs" . }}
           {{ .Content }}
         </div>

--- a/src/css/_layout.scss
+++ b/src/css/_layout.scss
@@ -99,6 +99,11 @@ $grid_widths: 2 3 4 5 6 8;
     width: 50%;
     margin: 0 auto;
   }
+
+  .on-tab-full {
+    width: 100%;
+    margin: 0;
+  }
 }
 
 

--- a/src/css/components/_tree.scss
+++ b/src/css/components/_tree.scss
@@ -18,7 +18,7 @@
       padding: 0 0 0 16px;
     }
 
-    @media (max-width:650px) {
+    @media (max-width:850px) {
       max-height: Min(30vh, 300px);
       border-radius: var(--radius);
       border: solid 4px #eee;


### PR DESCRIPTION
Tweak desktop guide layout for smartphone landscape mode or portrait mode on tablets.

Related to #3.

Signed-off-by: ricekot <ricekot@gmail.com>