### PR TITLE
Just support JDK 8 and 11 for ZAP development

### DIFF
--- a/site/content/docs/developer/quick-start-build.md
+++ b/site/content/docs/developer/quick-start-build.md
@@ -14,7 +14,8 @@ addSocialPreview: true
 Have you ever wanted to play around with the ZAP codebase but felt it was too overwhelming? This guide will walk you through building ZAP from the command line regardless of the operating system and IDE you're using. Let’s jump right into it!
 
 ## Preparation
-All you need is a working local installation of [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [JDK 8+](https://adoptopenjdk.net/).
+All you need is a working local installation of [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [JDK 8 or 11](https://adoptopenjdk.net/).
+Newer JDK versions might not work.
 
 ## Clone the Repo Locally
 Create a new directory on your system and run the following command in that directory to clone the core ZAP repository.


### PR DESCRIPTION
eg https://github.com/zaproxy/zaproxy/issues/6511

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
