### PR TITLE
Generate help of add-ons

### DIFF
--- a/site/content/docs/desktop/addons/linux-webdrivers/_index.md
+++ b/site/content/docs/desktop/addons/linux-webdrivers/_index.md
@@ -6,14 +6,14 @@ weight: 1
 cascade:
   addon:
     id: webdriverlinux
-    version: 27.0.0
+    version: 28.0.0
 ---
 
 # Linux WebDrivers
 
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 
-* Chrome - ChromeDriver 89.0.4389.23
+* Chrome - ChromeDriver 90.0.4430.24
 * Firefox - geckodriver 0.29.1
 
 ## See also

--- a/site/content/docs/desktop/addons/macos-webdrivers/_index.md
+++ b/site/content/docs/desktop/addons/macos-webdrivers/_index.md
@@ -6,14 +6,14 @@ weight: 1
 cascade:
   addon:
     id: webdrivermacos
-    version: 26.0.0
+    version: 27.0.0
 ---
 
 # MacOS WebDrivers
 
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 
-* Chrome - ChromeDriver 89.0.4389.23
+* Chrome - ChromeDriver 90.0.4430.24
 * Firefox - geckodriver 0.29.1
 
 ## See also

--- a/site/content/docs/desktop/addons/windows-webdrivers/_index.md
+++ b/site/content/docs/desktop/addons/windows-webdrivers/_index.md
@@ -6,14 +6,14 @@ weight: 1
 cascade:
   addon:
     id: webdriverwindows
-    version: 27.0.0
+    version: 28.0.0
 ---
 
 # Windows WebDrivers
 
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 
-* Chrome - ChromeDriver 89.0.4389.23
+* Chrome - ChromeDriver 90.0.4430.24
 * Firefox - geckodriver 0.29.1
 
 ## See also


### PR DESCRIPTION
Generate the help of the following add-ons:
 - Linux WebDrivers version 28;
 - MacOS WebDrivers version 27;
 - Windows WebDrivers version 28.