### PR TITLE
fix: Evantelists link that was 404

### DIFF
--- a/site/data/evangelists.yaml
+++ b/site/data/evangelists.yaml
@@ -81,7 +81,7 @@
     of <a href="https://purpleteam-labs.com" rel="nofollow">purpleteam</a>, 
     <a href="https://binarymist.io/publication/"
     rel="nofollow">Host for Software Engineering Radio</a>,
-    <a href="https://binarymist.io/talk/" rel="nofollow">Talks</a>,
+    <a href="https://binarymist.io/#talks-workshops" rel="nofollow">Talks</a>,
     <a href="https://binarymist.io/project/service-development-team-security-training/"
     rel="nofollow">Training</a>
     published author of many <a href="https://binarymist.io/publication/kims-selected-publications/"


### PR DESCRIPTION
Per: https://github.com/zaproxy/zaproxy-website/actions/runs/801301028

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
