### PR TITLE
fix: Evangelists

### DIFF
--- a/site/data/evangelists.yaml
+++ b/site/data/evangelists.yaml
@@ -95,7 +95,7 @@
   language: English
   has_talks: Y
   has_training: Y
-  notes: OWASP New Zealand chapter leader. <a href="https://binarymist.io/talk/" rel="nofollow">Public Talks and Workshops</a>
+  notes: ''
 
 - name: Adrien de Beaupre
   email: adriendb@gmail.com


### PR DESCRIPTION
See: https://github.com/zaproxy/zaproxy-website/runs/2715463145?check_suite_focus=true

I'm not sure why Dan Cornell's entry linked this. I think it was a copy/paste mistake.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
