### PR TITLE
Remove the community questionnaire

### DIFF
--- a/site/layouts/partials/homepage/feedback.html
+++ b/site/layouts/partials/homepage/feedback.html
@@ -1,7 +1,0 @@
-<section class="py-20">
-  <div class="wrapper">
-    <h5>We want to hear from you! If you use ZAP please fill in this 1 page  
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSfkLr91IKNnuaErBqD4X0dohEsJ6V9hFZOiPoTTbw6Ld4SJKQ/viewform">Community Questionnaire</a>
-    </h5>
-  </div>
-</section>


### PR DESCRIPTION
The plan is to turn the google form off and write a blog post about the results and what we're doing them.
Then add a new questionnaire (topic TBD) - thats why I've not completely removed the feedback.html page.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
