### PR TITLE
Mention increase of JVM memory in IntelliJ How To Page

### DIFF
--- a/site/content/docs/developer/building-zap-with-intellij-idea.md
+++ b/site/content/docs/developer/building-zap-with-intellij-idea.md
@@ -1,7 +1,7 @@
 ---
 title: "Building ZAP with IntelliJ IDEA"
 description: "This guide will get you started with building and running ZAP in IntelliJ IDEA."
-tags: 
+tags:
 - guide
 - tutorial
 type: page
@@ -12,6 +12,19 @@ This guide explains how to make changes to ZAP using IntelliJ IDEA.
 
 ## Preparation
 You will need to have followed the [Quick Start Guide to Building ZAP](../quick-start-build/) and installed a version of [IntelliJ IDEA](https://www.jetbrains.com/idea/download/).
+
+##### Gradle Resources
+Working with ZAP in IntelliJ IDEA may need a bit more Java resources for the Gradle actions. To adjust how much memory Gradle can use on your machine set the option in [gradle.properties](https://docs.gradle.org/current/userguide/build_environment.html)
+
+For Linux/OSX
+```bash
+echo 'org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=1g' >> ~/.gradle/gradle.properties
+```  
+
+For Windows
+```powershell
+echo "org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=1g" >> %USERPROFILE%\.gradle\gradle.properties
+```  
 
 ## Import the ZAP Repositories
 
@@ -51,7 +64,7 @@ ZAP will now start but it is not set up quite right and may show warning dialogs
 
 Select the 'Run' &#8594; 'Edit Configurations...' and then the `ZAP` configuration under 'Application'.
 
-Change the 'Working directory' by browsing to: `.../zaproxy/zap/src/main/dist/`. Here, `.../zaproxy` should be replaced by the complete path to the cloned _zaproxy_ repository on your system. 
+Change the 'Working directory' by browsing to: `.../zaproxy/zap/src/main/dist/`. Here, `.../zaproxy` should be replaced by the complete path to the cloned _zaproxy_ repository on your system.
 
 ![IntelliJ Run Configuration](/img/docs/developer/intellij-config-run.png)
 


### PR DESCRIPTION
Signed-off-by: Scott Gerlach <scott.gerlach@stackhawk.com>

**- Summary**
Gradle needs more memory to run correctly when using IntelliJ IDEA

**- Test plan**

Just a section in the single plage

**- Description for the changelog**

Updated the IntelliJ IDEA getting started with a section to allocate more memory for gradle

![RueCollar](https://user-images.githubusercontent.com/4514084/124163369-ca407380-da5c-11eb-9e8e-628ea1b56906.jpg)

