### PR TITLE
improve: faqs: Clarify content of home/user vs install directory

### DIFF
--- a/site/content/faq/what-is-the-default-directory-that-zap-uses.md
+++ b/site/content/faq/what-is-the-default-directory-that-zap-uses.md
@@ -7,35 +7,23 @@ weight: 2
 
 The default directory that ZAP uses depends on the OS.
 
-Note that you can override this using the -dir [command line](/docs/desktop/cmdline/) option.
+It can be overridden using the `-dir` [command line](/docs/desktop/cmdline/) option.
 
-##  Windows 7 / 8
+The default or home directory contains ZAP files added or modified at runtime. Including (but not limited to): config files, add-ons, input files, logs, etc. It is also the save location, for: scripts, active scan policy files, exported contexts, etc.
 
-    
-    
-    C:\Users\<username>\OWASP ZAP
-    
+Note: ZAP's home is not the same as the user's home directory, which is also OS dependent, and is the initial save location for sessions, reports, exported URLs, etc.
 
-##  Windows XP
+##  Windows 7 / 8 / 10
 
-    
-    
-    C:\Documents and Settings\<username>\OWASP ZAP
-    
+`C:\Users\<username>\OWASP ZAP`
 
 ##  Linux
 
-    
-    
-    ~/.ZAP
-    
+`~/.ZAP`
 
 ##  Mac OS
 
-    
-    
-    ~/Library/Application Support/ZAP
-    
+`~/Library/Application Support/ZAP`
 
 ##  Weekly releases
 

--- a/site/content/faq/where-is-zap-installed.md
+++ b/site/content/faq/where-is-zap-installed.md
@@ -5,25 +5,16 @@ category: General Questions
 weight: 2
 ---
 
-ZAP is installed in different places depending on the OS:
+ZAP is installed in different places depending on the OS.
 
-##  Windows 7
+The install directory contains everything that's bundled with ZAP originally.
 
-Underneath the 'Program Files (x86)' directory, e.g.
+##  Windows 7 / 8 / 10
 
-    
-    
-    C:\Program Files (x86)\OWASP\Zed Attack Proxy
-    
+Underneath the `Program Files` directory, e.g.
 
-##  Windows XP
-
-Underneath the 'Program Files' directory, e.g.
-
-    
-    
-    C:\Program Files\OWASP\Zed Attack Proxy
-    
+- `C:\Program Files\OWASP\Zed Attack Proxy` - For 64bit installs.
+- `C:\Program Files (x86)\OWASP\Zed Attack Proxy` - For 32bit installs.
 
 ##  Linux
 
@@ -35,4 +26,4 @@ wherever you expand the archive.
 Same as for Linux, the Mac OS package is just a zip file. The contained "Owasp
 ZAP" app can be executed instantly, regardless of the directory. As for any
 other Mac application, most users preferably put the app into the
-/Applications directory.
+`/Applications` directory.


### PR DESCRIPTION
I also removed the WinXP info as it's long past end of life, and cleaned up whitespace and code fencing.

Fixes zaproxy/zaproxy-website#508

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>