### PR TITLE
fix: check-links workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -20,5 +20,5 @@ jobs:
           cd hydra-link-checker
           wget -O evangelists.html https://www.zaproxy.org/evangelists/
           wget -O hof.html https://www.zaproxy.org/student-hall-of-fame/
-          python hydra.py file://$BASE/hydra-link-checker/evangelists.html $BASE/zaproxy-website/.github/workflows/conf/hydra.json
-          python hydra.py file://$BASE/hydra-link-checker/hof.html $BASE/zaproxy-website/.github/workflows/conf/hydra.json
+          python hydra.py file://$BASE/hydra-link-checker/evangelists.html --config $BASE/zaproxy-website/.github/workflows/conf/hydra.json
+          python hydra.py file://$BASE/hydra-link-checker/hof.html --config $BASE/zaproxy-website/.github/workflows/conf/hydra.json


### PR DESCRIPTION
Passing the config file to hydra now requires a switch not just a positional param.

Ref:
- https://github.com/victoriadrake/hydra-link-checker/releases
- https://github.com/zaproxy/zaproxy-website/runs/3762892619?check_suite_focus=true

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
