### PR TITLE
Correct page titles.

### DIFF
--- a/site/layouts/_default/post.html
+++ b/site/layouts/_default/post.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
 {{ define "main" }}
   <div class="wrapper py-70">
       <div class="flex latest-versions">

--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
 {{ define "main" }}
 <section class="bolt-header">
   <div class="wrapper py-20">

--- a/site/layouts/page/download.html
+++ b/site/layouts/page/download.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
 {{ define "main" }}
   <section class="bolt-header">
     <div class="wrapper py-20 download-header">

--- a/site/layouts/post/single.html
+++ b/site/layouts/post/single.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
 {{ define "main" }}
 {{ $section := .Site.GetPage "section" .Section }}
 <section class="bolt-header">

--- a/site/layouts/success/list.html
+++ b/site/layouts/success/list.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
 {{ define "main" }}
 <section class="bolt-header">
   <div class="wrapper py-20">

--- a/site/layouts/success/single.html
+++ b/site/layouts/success/single.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
 {{ define "main" }}
 <section class="bolt-header">
   <div class="wrapper py-20">

--- a/site/layouts/userguide/list.html
+++ b/site/layouts/userguide/list.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
 {{ define "main" }}
   <div class="wrapper py-30">
       <div class="flex latest-versions">

--- a/site/layouts/userguide/single.html
+++ b/site/layouts/userguide/single.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
 {{ define "main" }}
   <div class="wrapper py-30">
       <div class="flex latest-versions">


### PR DESCRIPTION
Many of the pages currently have the default "OWASP ZAP title" eg:

* Downloads
* Blog + blog entries
* Desktop user guide
* Success + stories

This should fix that...

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
