### PR TITLE
fix: Link Check GHA Workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,7 +18,9 @@ jobs:
           git clone --depth 1 https://github.com/zaproxy/zaproxy-website.git
           git clone --depth 1 https://github.com/victoriadrake/hydra-link-checker.git
           cd hydra-link-checker
+          git fetch --all --tags
+          git checkout v1.0.2
           wget -O evangelists.html https://www.zaproxy.org/evangelists/
           wget -O hof.html https://www.zaproxy.org/student-hall-of-fame/
-          python hydra.py file://$BASE/hydra-link-checker/evangelists.html --config $BASE/zaproxy-website/.github/workflows/conf/hydra.json
-          python hydra.py file://$BASE/hydra-link-checker/hof.html --config $BASE/zaproxy-website/.github/workflows/conf/hydra.json
+          python hydra.py file://$BASE/hydra-link-checker/evangelists.html $BASE/zaproxy-website/.github/workflows/conf/hydra.json
+          python hydra.py file://$BASE/hydra-link-checker/hof.html $BASE/zaproxy-website/.github/workflows/conf/hydra.json

--- a/site/data/evangelists.yaml
+++ b/site/data/evangelists.yaml
@@ -202,7 +202,7 @@
   language: English, French
   has_talks: Y
   has_training: Y
-  notes: <a href="http://www.frhack.org" rel="nofollow">http://www.frhack.org</a>
+  notes: ''
 
 - name: Michael Coates
   email: michael.coates@owasp.org 


### PR DESCRIPTION
- Specifically checkout hydra v1.0.2.
- Address the frhack.org 400/404 in evangelists (per: https://github.com/kingthorin/wftest/runs/4047664692?check_suite_focus=true)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>