### PR TITLE
Add breadcrumbs option

### DIFF
--- a/site/content/docs/authentication/_index.md
+++ b/site/content/docs/authentication/_index.md
@@ -38,6 +38,7 @@ links:
 
 cascade:
   EditableContent: true
+  addBreadcrumbs: true
 ---
 
 Most apps protect their main functionality using authentication.

--- a/site/layouts/page/single.html
+++ b/site/layouts/page/single.html
@@ -9,6 +9,7 @@
 </section>
 <section class="wrapper flex py-70 on-sm-stack" data-kind="{{ .Kind }}">
   <article class="on-sm-full">
+  {{ if .Params.addBreadcrumbs }}{{partial "crumbs.html" . }}{{ end }}
     <main>{{- .Content -}}</main>
   </article>
 </section>


### PR DESCRIPTION
Allow any page to include breadcrumbs, and enable for all of the authentication pages.

![Screenshot 2021-11-15 at 15-18-23 OWASP ZAP – Authentication - Make your Life Easier](https://user-images.githubusercontent.com/1081115/141806833-615141bf-993b-4040-97b7-888e9d65f02e.png)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
