### PR TITLE
Add Alert Tag pages

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -8,6 +8,7 @@ summaryLength: 48
 taxonomies:
   tag: "tags"
   successtag: "successtags"
+  alerttag: "alerttags"
   author: "authors"
 
 params:

--- a/site/content/docs/alerts/0.md
+++ b/site/content/docs/alerts/0.md
@@ -14,11 +14,11 @@ references:
 cwe: 548
 wasc: 48
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+  - OWASP_2021_A01
+  - OWASP_2017_A05
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 It is possible to view the directory listing.  Directory listing may reveal hidden scripts, include files, backup source files, etc. which can be accessed to read sensitive information.

--- a/site/content/docs/alerts/10003.md
+++ b/site/content/docs/alerts/10003.md
@@ -8,11 +8,11 @@ status: release
 type: alert
 solution: "_Unavailable_"
 alerttags: 
-   OWASP_2017_A09: https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities.html
-   OWASP_2021_A06: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
+  - OWASP_2017_A09
+  - OWASP_2021_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
 linktext: org/zaproxy/addon/retire/RetireScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 _Unavailable_

--- a/site/content/docs/alerts/10009.md
+++ b/site/content/docs/alerts/10009.md
@@ -12,11 +12,11 @@ Under Apache this is done via the 'ServerSignature' and 'ServerTokens' directive
 references:
    - https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The server returned a version banner string in the response content. Such information leaks may allow attackers to further target specific issues impacting the product and version in use.

--- a/site/content/docs/alerts/10010.md
+++ b/site/content/docs/alerts/10010.md
@@ -13,11 +13,11 @@ references:
 cwe: 1004
 wasc: 13
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.

--- a/site/content/docs/alerts/10011.md
+++ b/site/content/docs/alerts/10011.md
@@ -13,11 +13,11 @@ references:
 cwe: 614
 wasc: 13
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A cookie has been set without the secure flag, which means that the cookie can be accessed via unencrypted connections.

--- a/site/content/docs/alerts/10015.md
+++ b/site/content/docs/alerts/10015.md
@@ -16,7 +16,7 @@ wasc: 13
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The cache-control header has not been set properly or is missing, allowing the browser and proxies to cache content.

--- a/site/content/docs/alerts/10017.md
+++ b/site/content/docs/alerts/10017.md
@@ -11,10 +11,10 @@ solution: "Ensure JavaScript source files are loaded from only trusted sources, 
 cwe: 829
 wasc: 15
 alerttags: 
-   OWASP_2021_A08: https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/
+  - OWASP_2021_A08
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The page includes one or more script files from a third-party domain.

--- a/site/content/docs/alerts/10019.md
+++ b/site/content/docs/alerts/10019.md
@@ -13,11 +13,11 @@ references:
 cwe: 345
 wasc: 12
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The Content-Type header was either missing or empty.

--- a/site/content/docs/alerts/10020-1.md
+++ b/site/content/docs/alerts/10020-1.md
@@ -13,11 +13,11 @@ references:
 cwe: 1021
 wasc: 15
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.

--- a/site/content/docs/alerts/10020-2.md
+++ b/site/content/docs/alerts/10020-2.md
@@ -13,11 +13,11 @@ references:
 cwe: 1021
 wasc: 15
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 X-Frame-Options (XFO) headers were found, a response with multiple XFO header entries may not be predictably treated by all user-agents.

--- a/site/content/docs/alerts/10020-3.md
+++ b/site/content/docs/alerts/10020-3.md
@@ -13,11 +13,11 @@ references:
 cwe: 1021
 wasc: 15
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 An X-Frame-Options (XFO) META tag was found, defining XFO via a META tag is explicitly not supported by the spec (RFC 7034).

--- a/site/content/docs/alerts/10020-4.md
+++ b/site/content/docs/alerts/10020-4.md
@@ -13,11 +13,11 @@ references:
 cwe: 1021
 wasc: 15
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 An X-Frame-Options header was present in the response but the value was not correctly set.

--- a/site/content/docs/alerts/10020.md
+++ b/site/content/docs/alerts/10020.md
@@ -20,6 +20,6 @@ alerts:
       name: X-Frame-Options Setting Malformed
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
 linktext: "org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java"
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---

--- a/site/content/docs/alerts/10021.md
+++ b/site/content/docs/alerts/10021.md
@@ -15,11 +15,11 @@ references:
 cwe: 693
 wasc: 15
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.

--- a/site/content/docs/alerts/10023.md
+++ b/site/content/docs/alerts/10023.md
@@ -11,11 +11,11 @@ solution: "Disable debugging messages before pushing to production."
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A01
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The response appeared to contain common error messages returned by platforms such as ASP.NET, and Web-servers such as IIS and Apache. You can configure the list of common debug messages.

--- a/site/content/docs/alerts/10024.md
+++ b/site/content/docs/alerts/10024.md
@@ -11,11 +11,11 @@ solution: "Do not pass sensitive information in URIs."
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A01
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The request appeared to contain sensitive information leaked in the URL. This can violate PCI and most organizational compliance policies. You can configure the list of strings for this check to add or remove values specific to your environment.

--- a/site/content/docs/alerts/10025.md
+++ b/site/content/docs/alerts/10025.md
@@ -11,11 +11,11 @@ solution: "Do not pass sensitive information in URIs."
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A01
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The HTTP header may have leaked a potentially sensitive parameter to another domain. This can violate PCI and most organizational compliance policies. You can configure the list of strings for this check to add or remove values specific to your environment.

--- a/site/content/docs/alerts/10026.md
+++ b/site/content/docs/alerts/10026.md
@@ -10,11 +10,11 @@ solution: "All forms must specify the action URL."
 references:
    - http://download.oracle.com/javaee-archive/servlet-spec.java.net/jsr340-experts/att-0317/OnParameterPollutionAttacks.pdf
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A04
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Unspecified form action: HTTP parameter override attack potentially possible. This is a known problem with Java Servlets but other platforms may also be vulnerable.

--- a/site/content/docs/alerts/10027.md
+++ b/site/content/docs/alerts/10027.md
@@ -11,11 +11,11 @@ solution: "Remove all comments that return information that may help an attacker
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A01
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The response appears to contain suspicious comments which may help an attacker. Note: Matches made within script blocks or files are against the entire content not only comments.

--- a/site/content/docs/alerts/10028.md
+++ b/site/content/docs/alerts/10028.md
@@ -11,12 +11,12 @@ references:
    - https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
    - https://cwe.mitre.org/data/definitions/601.html
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Open redirects are one of the OWASP 2010 Top Ten vulnerabilities. This check looks at user-supplied input in query string parameters and POST data to identify where open redirects might be possible. Open redirects occur when an application allows user-supplied input (e.g. http://nottrusted.com) to control an offsite redirect. This is generally a pretty accurate way to find where 301 or 302 redirects could be exploited by spammers or phishing attacks.
 

--- a/site/content/docs/alerts/10029.md
+++ b/site/content/docs/alerts/10029.md
@@ -10,11 +10,11 @@ solution: "Do not allow user input to control cookie names and values. If some q
 references:
    - http://websecuritytool.codeplex.com/wikipage?title=Checks#user-controlled-cookie
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This check looks at user-supplied input in query string parameters and POST data to identify where cookie parameters might be controlled. This is called a cookie poisoning attack, and becomes exploitable when an attacker can manipulate the cookie in various ways. In some cases this will not be exploitable, however, allowing URL parameters to set cookie values is generally considered a bug.

--- a/site/content/docs/alerts/10030.md
+++ b/site/content/docs/alerts/10030.md
@@ -8,11 +8,11 @@ status: beta
 type: alert
 solution: "Force UTF-8 in all charset declarations. If user-input is required to decide a charset declaration, ensure that only an allowed list is used."
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This check looks at user-supplied input in query string parameters and POST data to identify where Content-Type or meta tag charset declarations might be user-controlled. Such charset declarations should always be declared by the application. If an attacker can control the response charset, they could manipulate the HTML to perform XSS or other attacks. For example, an attacker controlling the <meta> element charset value is able to declare UTF-7 and is also able to include enough user-controlled payload early in the HTML document to have it interpreted as UTF-7. By encoding their payload with UTF-7 the attacker is able to bypass any server-side XSS protections and embed script in the page.

--- a/site/content/docs/alerts/10031.md
+++ b/site/content/docs/alerts/10031.md
@@ -10,11 +10,11 @@ solution: "Validate all input and sanitize output it before writing to any HTML 
 references:
    - http://websecuritytool.codeplex.com/wikipage?title=Checks#user-controlled-html-attribute
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.

--- a/site/content/docs/alerts/10032-1.md
+++ b/site/content/docs/alerts/10032-1.md
@@ -11,11 +11,11 @@ solution: "Verify the provided information isn't confidential."
 cwe: 642
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A04
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The following potential IP addresses were found being serialized in the viewstate field:

--- a/site/content/docs/alerts/10032-2.md
+++ b/site/content/docs/alerts/10032-2.md
@@ -11,11 +11,11 @@ solution: "Verify the provided information isn't confidential."
 cwe: 642
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A04
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The following emails were found being serialized in the viewstate field:

--- a/site/content/docs/alerts/10032-3.md
+++ b/site/content/docs/alerts/10032-3.md
@@ -11,12 +11,12 @@ solution: "Ensure the engaged framework is still supported by Microsoft."
 cwe: 642
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A04
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 *** EXPERIMENTAL ***
 This website uses ASP.NET version 1.0 or 1.1.

--- a/site/content/docs/alerts/10032-4.md
+++ b/site/content/docs/alerts/10032-4.md
@@ -13,12 +13,12 @@ references:
 cwe: 642
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A04
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 *** EXPERIMENTAL ***
 This website uses ASP.NET's Viewstate but maybe without any MAC.

--- a/site/content/docs/alerts/10032-5.md
+++ b/site/content/docs/alerts/10032-5.md
@@ -13,12 +13,12 @@ references:
 cwe: 642
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A04
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 *** EXPERIMENTAL ***
 This website uses ASP.NET's Viewstate but without any MAC.

--- a/site/content/docs/alerts/10032-6.md
+++ b/site/content/docs/alerts/10032-6.md
@@ -11,12 +11,12 @@ solution: "None - the guys running the server may have tuned the configuration a
 cwe: 642
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A04
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 *** EXPERIMENTAL ***
 This website uses ASP.NET's Viewstate and its value is split into several chunks.

--- a/site/content/docs/alerts/10032.md
+++ b/site/content/docs/alerts/10032.md
@@ -26,6 +26,6 @@ alerts:
       name: Split Viewstate in Use
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
 linktext: "org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java"
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---

--- a/site/content/docs/alerts/10033.md
+++ b/site/content/docs/alerts/10033.md
@@ -10,11 +10,11 @@ solution: "Configure the web server to disable directory browsing. "
 references:
    - https://cwe.mitre.org/data/definitions/548.html
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 It is possible to view a listing of the directory contents. Directory listings may reveal hidden scripts, include files , backup source files, etc., which be accessed to reveal sensitive information.

--- a/site/content/docs/alerts/10034.md
+++ b/site/content/docs/alerts/10034.md
@@ -10,11 +10,11 @@ solution: "Update to OpenSSL 1.0.1g or later. Re-issue HTTPS certificates. Chang
 references:
    - http://cvedetails.com/cve-details.php?t=1&cve_id=CVE-2014-0160
 alerttags: 
-   OWASP_2017_A09: https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities.html
-   OWASP_2021_A06: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
+  - OWASP_2017_A09
+  - OWASP_2021_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The TLS and DTLS implementations in OpenSSL 1.0.1 before 1.0.1g do not properly handle Heartbeat Extension packets, which allows remote attackers to obtain sensitive information from process memory via crafted packets that trigger a buffer over-read, potentially disclosing sensitive information.	

--- a/site/content/docs/alerts/10035.md
+++ b/site/content/docs/alerts/10035.md
@@ -14,11 +14,11 @@ references:
    - http://caniuse.com/stricttransportsecurity
    - http://tools.ietf.org/html/rfc6797
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 HTTP Strict Transport Security (HSTS) is a web security policy mechanism whereby a web server declares that complying user agents (such as a web browser) are to interact with it using only secure HTTPS connections (i.e. HTTP layered over TLS/SSL). HSTS is an IETF standards track protocol and is specified in RFC 6797.

--- a/site/content/docs/alerts/10036.md
+++ b/site/content/docs/alerts/10036.md
@@ -8,11 +8,11 @@ status: beta
 type: alert
 solution: "_Unavailable_"
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 _Unavailable_

--- a/site/content/docs/alerts/10037.md
+++ b/site/content/docs/alerts/10037.md
@@ -14,11 +14,11 @@ references:
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A01
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The web/application server is leaking information via one or more "X-Powered-By" HTTP response headers. Access to such information may facilitate attackers identifying other frameworks/components your web application is reliant upon and the vulnerabilities such components may be subject to.

--- a/site/content/docs/alerts/10038.md
+++ b/site/content/docs/alerts/10038.md
@@ -16,11 +16,11 @@ references:
    - http://caniuse.com/#feat=contentsecuritypolicy
    - http://content-security-policy.com/
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.

--- a/site/content/docs/alerts/10039.md
+++ b/site/content/docs/alerts/10039.md
@@ -8,11 +8,11 @@ status: beta
 type: alert
 solution: "Ensure that your web server, application server, load balancer, etc. is configured to suppress X-Backend-Server headers."
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The server is leaking information pertaining to backend systems (such as hostnames or IP addresses). Armed with this information an attacker may be able to attack other systems or more directly/efficiently attack those systems.

--- a/site/content/docs/alerts/10040.md
+++ b/site/content/docs/alerts/10040.md
@@ -14,11 +14,11 @@ references:
 cwe: 311
 wasc: 4
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The page includes mixed content, that is content accessed via HTTP instead of HTTPS.

--- a/site/content/docs/alerts/10041.md
+++ b/site/content/docs/alerts/10041.md
@@ -8,11 +8,11 @@ status: beta
 type: alert
 solution: "Use HTTPS for landing pages that host secure forms."
 alerttags: 
-   OWASP_2021_A02: https://owasp.org/Top10/A02_2021-Cryptographic_Failures/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A02
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This check looks for insecure HTTP pages that host HTTPS forms. The issue is that an insecure HTTP page can easily be hijacked through MITM and the secure HTTPS form can be replaced or spoofed.

--- a/site/content/docs/alerts/10042.md
+++ b/site/content/docs/alerts/10042.md
@@ -8,11 +8,11 @@ status: beta
 type: alert
 solution: "Ensure sensitive data is only sent over secured HTTPS channels."
 alerttags: 
-   OWASP_2021_A02: https://owasp.org/Top10/A02_2021-Cryptographic_Failures/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A02
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This check identifies secure HTTPS pages that host insecure HTTP forms. The issue is that a secure page is transitioning to an insecure page when data is uploaded through a form. The user may think they're submitting data to a secure page when in fact they are not.

--- a/site/content/docs/alerts/10043.md
+++ b/site/content/docs/alerts/10043.md
@@ -10,11 +10,11 @@ solution: "Validate all input and sanitize output it before writing to any Javas
 references:
    - http://websecuritytool.codeplex.com/wikipage?title=Checks#user-javascript-event
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.            

--- a/site/content/docs/alerts/10044.md
+++ b/site/content/docs/alerts/10044.md
@@ -8,11 +8,11 @@ status: beta
 type: alert
 solution: "Ensure that no sensitive information is leaked via redirect responses. Redirect responses should have almost no content."
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A04
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The server has responded with a redirect that seems to provide a large response. This may indicate that although the server sent a redirect it also responded with body content (which may include sensitive details, PII, etc.).

--- a/site/content/docs/alerts/10045.md
+++ b/site/content/docs/alerts/10045.md
@@ -16,12 +16,12 @@ references:
 cwe: 541
 wasc: 34
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Predictable Resource Location is an attack technique used to uncover hidden web site content and functionality. By making educated guesses via brute forcing an attacker can guess file and directory names not intended for public viewing. Brute forcing filenames is easy because files/paths often have common naming convention and reside in standard locations. These can include temporary files, backup files, logs, administrative site sections, configuration files, demo applications, and sample files. These files may disclose sensitive information about the website, web application internals, database information, passwords, machine names, file paths to other sensitive areas, etc...
 

--- a/site/content/docs/alerts/10047.md
+++ b/site/content/docs/alerts/10047.md
@@ -17,11 +17,9 @@ references:
 cwe: 311
 wasc: 4
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Content which was initially accessed via HTTPS (i.e.: using SSL/TLS encryption) is also accessible via HTTP (without encryption). 

--- a/site/content/docs/alerts/10048.md
+++ b/site/content/docs/alerts/10048.md
@@ -14,11 +14,9 @@ references:
 cwe: 78
 wasc: 31
 alerttags: 
-   OWASP_2017_A09: https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities.html
-   OWASP_2021_A06: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The server is running a version of the Bash shell that allows remote attackers to execute arbitrary code 

--- a/site/content/docs/alerts/10049.md
+++ b/site/content/docs/alerts/10049.md
@@ -10,7 +10,7 @@ solution: "_Unavailable_"
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 _Unavailable_

--- a/site/content/docs/alerts/10050.md
+++ b/site/content/docs/alerts/10050.md
@@ -18,7 +18,7 @@ references:
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The content was retrieved from a shared cache. If the response data is sensitive, personal or user-specific, this may result in sensitive information being leaked. In some cases, this may even result in a user gaining complete control of the session of another user, depending on the configuration of the caching components in use in their environment. This is primarily an issue where caching servers such as "proxy" caches are configured on the local network. This configuration is typically found in corporate or educational environments, for instance. 

--- a/site/content/docs/alerts/10051.md
+++ b/site/content/docs/alerts/10051.md
@@ -20,11 +20,9 @@ references:
 cwe: 20
 wasc: 20
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The web server is configured to serve responses to ambiguous URLs in a manner that is likely to lead to confusion about the correct "relative path" for the URL. Resources (CSS, images, etc.) are also specified in the page response using relative, rather than absolute URLs. In an attack, if the web browser parses the "cross-content" response in a permissive manner, or can be tricked into permissively parsing the "cross-content" response, using techniques such as framing, then the web browser may be fooled into interpreting HTML as CSS (or other content types), leading to an XSS vulnerability.

--- a/site/content/docs/alerts/10052.md
+++ b/site/content/docs/alerts/10052.md
@@ -10,11 +10,11 @@ solution: "Disable this functionality in Production when it might leak informati
 references:
    - https://craig.is/writing/chrome-logger
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A04
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The server is leaking information through the X-ChromeLogger-Data (or X-ChromePhp-Data) response header. The content of such headers can be customized by the developer, however it is not uncommon to find: server file system locations, vhost declarations, etc.

--- a/site/content/docs/alerts/10054.md
+++ b/site/content/docs/alerts/10054.md
@@ -13,11 +13,11 @@ references:
 cwe: 1275
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+  - OWASP_2021_A01
+  - OWASP_2017_A05
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A cookie has been set without the SameSite attribute, which means that the cookie can be sent as a result of a 'cross-site' request. The SameSite attribute is an effective counter measure to cross-site request forgery, cross-site script inclusion, and timing attacks.

--- a/site/content/docs/alerts/10055.md
+++ b/site/content/docs/alerts/10055.md
@@ -17,11 +17,11 @@ references:
 cwe: 693
 wasc: 15
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks. Including (but not limited to) Cross Site Scripting (XSS), and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.

--- a/site/content/docs/alerts/10056.md
+++ b/site/content/docs/alerts/10056.md
@@ -14,11 +14,11 @@ references:
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A01
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The response contained an X-Debug-Token or X-Debug-Token-Link header. This indicates that Symfony's Profiler may be in use and exposing sensitive data.

--- a/site/content/docs/alerts/10057.md
+++ b/site/content/docs/alerts/10057.md
@@ -13,11 +13,11 @@ references:
 cwe: 284
 wasc: 2
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+  - OWASP_2021_A01
+  - OWASP_2017_A05
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A hash of a username ({0}) was found in the response. This may indicate that the application is subject to an Insecure Direct Object Reference (IDOR) vulnerability. Manual testing will be required to see if this discovery can be abused.

--- a/site/content/docs/alerts/10058.md
+++ b/site/content/docs/alerts/10058.md
@@ -11,11 +11,9 @@ solution: "Ensure that only POST is accepted where POST is expected."
 cwe: 16
 wasc: 20
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GetForPostScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/GetForPostScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A request that was originally observed as a POST was also accepted as a GET. This issue does not represent a security weakness unto itself, however, it may facilitate simplification of other attacks. For example if the original POST is subject to Cross-Site Scripting (XSS), then this finding may indicate that a simplified (GET based) XSS may also be possible.

--- a/site/content/docs/alerts/10061.md
+++ b/site/content/docs/alerts/10061.md
@@ -14,11 +14,11 @@ references:
 cwe: 933
 wasc: 14
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Server leaks information via "X-AspNet-Version"/"X-AspNetMvc-Version" HTTP response header field(s).

--- a/site/content/docs/alerts/10062.md
+++ b/site/content/docs/alerts/10062.md
@@ -8,11 +8,11 @@ status: beta
 type: alert
 solution: "_Unavailable_"
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A04
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.

--- a/site/content/docs/alerts/10063.md
+++ b/site/content/docs/alerts/10063.md
@@ -14,11 +14,11 @@ references:
    - https://w3c.github.io/webappsec-feature-policy/
    - https://www.smashingmagazine.com/2018/12/feature-policy/
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+  - OWASP_2021_A01
+  - OWASP_2017_A05
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Permissions Policy Header is an added layer of security that helps to restrict from unauthorized access or usage of browser/client features by web resources. This policy ensures the user privacy by limiting or specifying the features of the browsers can be used by the web resources. Permissions Policy provides a set of standard HTTP headers that allow website owners to limit which features of browsers can be used by the page such as camera, microphone, location, full screen etc.

--- a/site/content/docs/alerts/10094.md
+++ b/site/content/docs/alerts/10094.md
@@ -10,11 +10,11 @@ solution: "Manually confirm that the Base64 data does not leak sensitive informa
 references:
    - http://projects.webappsec.org/w/page/13246936/Information%20Leakage
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A04
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Base64 encoded data was disclosed by the application/web server. Note: in the interests of performance not all base64 strings in the response were analyzed individually, the entire response should be looked at by the analyst/security team/developer(s).

--- a/site/content/docs/alerts/10095.md
+++ b/site/content/docs/alerts/10095.md
@@ -16,11 +16,9 @@ references:
 cwe: 530
 wasc: 34
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A backup of the file was disclosed by the web server

--- a/site/content/docs/alerts/10096.md
+++ b/site/content/docs/alerts/10096.md
@@ -13,11 +13,11 @@ references:
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A01
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A timestamp was disclosed by the application/web server

--- a/site/content/docs/alerts/10097.md
+++ b/site/content/docs/alerts/10097.md
@@ -11,11 +11,11 @@ references:
    - http://projects.webappsec.org/w/page/13246936/Information%20Leakage
    - http://openwall.info/wiki/john/sample-hashes
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A04
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A hash was disclosed by the web server.

--- a/site/content/docs/alerts/10098.md
+++ b/site/content/docs/alerts/10098.md
@@ -14,11 +14,11 @@ references:
 cwe: 264
 wasc: 14
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+  - OWASP_2021_A01
+  - OWASP_2017_A05
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Web browser data loading may be possible, due to a Cross Origin Resource Sharing (CORS) misconfiguration on the web server

--- a/site/content/docs/alerts/10099.md
+++ b/site/content/docs/alerts/10099.md
@@ -10,11 +10,11 @@ solution: "Ensure that application Source Code is not available with alternative
 references:
    - http://blogs.wsj.com/cio/2013/10/08/adobe-source-code-leak-is-bad-news-for-u-s-government/
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Application Source Code was disclosed by the web server

--- a/site/content/docs/alerts/10103.md
+++ b/site/content/docs/alerts/10103.md
@@ -13,8 +13,8 @@ references:
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
 linktext: org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
 date: 2021-10-14 08:21:59.220Z

--- a/site/content/docs/alerts/10104.md
+++ b/site/content/docs/alerts/10104.md
@@ -13,7 +13,7 @@ references:
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Check for differences in response based on fuzzed User Agent (eg. mobile sites, access as a Search Engine Crawler). Compares the response statuscode and the hashcode of the response body with the original response.

--- a/site/content/docs/alerts/10105.md
+++ b/site/content/docs/alerts/10105.md
@@ -9,16 +9,10 @@ type: alert
 solution: "Protect the connection using HTTPS or use a stronger authentication mechanism"
 references:
    - https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
-cwe: 326
-wasc: 4
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2021_A02: https://owasp.org/Top10/A02_2021-Cryptographic_Failures/
-   OWASP_2017_A02: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication.html
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 HTTP basic or digest authentication has been used over an unsecured connection. The credentials can be read and then reused by someone with access to the network.

--- a/site/content/docs/alerts/10106.md
+++ b/site/content/docs/alerts/10106.md
@@ -14,11 +14,9 @@ references:
 cwe: 311
 wasc: 4
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The site is only served under HTTP and not HTTPS.

--- a/site/content/docs/alerts/10107.md
+++ b/site/content/docs/alerts/10107.md
@@ -13,12 +13,10 @@ references:
 cwe: 20
 wasc: 20
 alerttags: 
-   OWASP_2017_A09: https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities.html
-   OWASP_2021_A06: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttPoxyScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/HttPoxyScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The server initiated a proxied request via the proxy specified in the HTTP Proxy header of the request.Httpoxy typically affects code running in CGI or CGI like environments.
 This may allow attackers to:

--- a/site/content/docs/alerts/10108.md
+++ b/site/content/docs/alerts/10108.md
@@ -13,11 +13,11 @@ references:
    - https://mathiasbynens.github.io/rel-noopener/
    - https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A04
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 At least one link on this page is vulnerable to Reverse tabnabbing as it uses a target attribute without using both of the "noopener" and "noreferrer" keywords in the "rel" attribute, which allows the target page to take control of this page.

--- a/site/content/docs/alerts/10109.md
+++ b/site/content/docs/alerts/10109.md
@@ -10,7 +10,7 @@ solution: "This is an informational alert and so no changes are required."
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The application appears to be a modern web application. If you need to explore it automatically then the Ajax Spider may well be more effective than the standard one.

--- a/site/content/docs/alerts/10110.md
+++ b/site/content/docs/alerts/10110.md
@@ -10,10 +10,10 @@ solution: "See the references for security advice on the use of these functions.
 references:
    - https://angular.io/guide/security
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
+  - OWASP_2021_A04
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A dangerous JS function seems to be in use that would leave the site vulnerable.

--- a/site/content/docs/alerts/10202.md
+++ b/site/content/docs/alerts/10202.md
@@ -33,12 +33,12 @@ references:
 cwe: 352
 wasc: 9
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+  - OWASP_2021_A01
+  - OWASP_2017_A05
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A cross-site request forgery is an attack that involves forcing a victim to send an HTTP request to a target destination without their knowledge or intent in order to perform an action as the victim. The underlying cause is application functionality using predictable URL/form actions in a repeatable way. The nature of the attack is that CSRF exploits the trust that a web site has for a user. By contrast, cross-site scripting (XSS) exploits the trust that a user has for a web site. Like XSS, CSRF attacks are not necessarily cross-site, but they can be. Cross-site request forgery is also known as CSRF, XSRF, one-click attack, session riding, confused deputy, and sea surf.
 

--- a/site/content/docs/alerts/110001.md
+++ b/site/content/docs/alerts/110001.md
@@ -13,7 +13,7 @@ wasc: 13
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Application%20Error%20Scanner.js
 linktext: scripts/templates/websocketpassive/Application Error Scanner.js
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This payload contains an error/warning message that may disclose sensitive information like the location of the file that produced the unhandled exception. This information can be used to launch further attacks against the web application.

--- a/site/content/docs/alerts/110002.md
+++ b/site/content/docs/alerts/110002.md
@@ -11,7 +11,7 @@ solution: "Base64-encoding should not be used to store or send sensitive informa
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Base64%20Disclosure.js
 linktext: scripts/templates/websocketpassive/Base64 Disclosure.js
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A Base64-encoded string has been found in the websocket incoming message. Base64-encoded data may contain sensitive information such as usernames, passwords or cookies which should be further inspected. Decoded evidence: example.

--- a/site/content/docs/alerts/110003.md
+++ b/site/content/docs/alerts/110003.md
@@ -13,7 +13,7 @@ wasc: 13
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Debug%20Error%20Disclosure.js
 linktext: scripts/templates/websocketpassive/Debug Error Disclosure.js
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The response appeared to contain common error messages returned by platforms such as ASP.NET, and Web-servers such as IIS and Apache. You can configure the list of common debug messages.

--- a/site/content/docs/alerts/110004.md
+++ b/site/content/docs/alerts/110004.md
@@ -13,7 +13,7 @@ wasc: 13
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Email%20Disclosure.js
 linktext: scripts/templates/websocketpassive/Email Disclosure.js
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 An email address was found in a WebSocket Message.

--- a/site/content/docs/alerts/110005.md
+++ b/site/content/docs/alerts/110005.md
@@ -13,7 +13,7 @@ wasc: 13
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/PII%20Disclosure.js
 linktext: scripts/templates/websocketpassive/PII Disclosure.js
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The response contains Personally Identifiable Information, such as CC number. Credit Card type detected: undefined.

--- a/site/content/docs/alerts/110006.md
+++ b/site/content/docs/alerts/110006.md
@@ -13,7 +13,7 @@ references:
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Private%20IP%20Disclosure.js
 linktext: scripts/templates/websocketpassive/Private IP Disclosure.js
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A private IP (such as 10.x.x.x, 172.x.x.x, 192.168.x.x) or an Amazon EC2 private hostname (for example, ip-10-0-56-78) has been found in the incoming WebSocket message. This information might be helpful for further attacks targeting internal systems.

--- a/site/content/docs/alerts/110007.md
+++ b/site/content/docs/alerts/110007.md
@@ -16,7 +16,7 @@ wasc: 2
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Username%20Idor%20Scanner.js
 linktext: scripts/templates/websocketpassive/Username Idor Scanner.js
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A Example hash of {Example / context: Example} was found in incoming WebSocket message. This may indicate that the application is subject to an Insecure Direct Object Reference (IDOR) vulnerability. Manual testing will be required to see if this discovery can be abused.

--- a/site/content/docs/alerts/110008.md
+++ b/site/content/docs/alerts/110008.md
@@ -13,7 +13,7 @@ wasc: 13
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/XML%20Comments%20Disclosure.js
 linktext: scripts/templates/websocketpassive/XML Comments Disclosure.js
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The response appears to contain suspicious comments which may help an attacker.

--- a/site/content/docs/alerts/2.md
+++ b/site/content/docs/alerts/2.md
@@ -13,11 +13,11 @@ references:
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A01
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A private IP (such as 10.x.x.x, 172.x.x.x, 192.168.x.x) or an Amazon EC2 private hostname (for example, ip-10-0-56-78) has been found in the HTTP response body. This information might be helpful for further attacks targeting internal systems.

--- a/site/content/docs/alerts/20012.md
+++ b/site/content/docs/alerts/20012.md
@@ -34,12 +34,10 @@ references:
 cwe: 352
 wasc: 9
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A cross-site request forgery is an attack that involves forcing a victim to send an HTTP request to a target destination without their knowledge or intent in order to perform an action as the victim. The underlying cause is application functionality using predictable URL/form actions in a repeatable way. The nature of the attack is that CSRF exploits the trust that a web site has for a user. By contrast, cross-site scripting (XSS) exploits the trust that a user has for a web site. Like XSS, CSRF attacks are not necessarily cross-site, but they can be. Cross-site request forgery is also known as CSRF, XSRF, one-click attack, session riding, confused deputy, and sea surf.
 

--- a/site/content/docs/alerts/20014.md
+++ b/site/content/docs/alerts/20014.md
@@ -13,11 +13,9 @@ references:
 cwe: 20
 wasc: 20
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 HTTP Parameter Pollution (HPP) attacks consist of injecting encoded query string delimiters into other existing parameters. If a web application does not properly sanitize the user input, a malicious user can compromise the logic of the application to perform either client-side or server-side attacks. One consequence of HPP attacks is that the attacker can potentially override existing hard-coded HTTP parameters to modify the behavior of an application, bypass input validation checkpoints, and access and possibly exploit variables that may be out of direct reach.

--- a/site/content/docs/alerts/20015.md
+++ b/site/content/docs/alerts/20015.md
@@ -13,11 +13,9 @@ references:
 cwe: 119
 wasc: 20
 alerttags: 
-   OWASP_2017_A09: https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities.html
-   OWASP_2021_A06: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The TLS implementation in OpenSSL 1.0.1 before 1.0.1g does not properly handle Heartbeat Extension packets, which allows remote attackers to obtain sensitive information from process memory via crafted packets that trigger a buffer over-read, potentially disclosing sensitive information.

--- a/site/content/docs/alerts/20016.md
+++ b/site/content/docs/alerts/20016.md
@@ -16,11 +16,9 @@ references:
 cwe: 264
 wasc: 14
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 

--- a/site/content/docs/alerts/20017.md
+++ b/site/content/docs/alerts/20017.md
@@ -42,12 +42,10 @@ references:
 cwe: 20
 wasc: 20
 alerttags: 
-   OWASP_2017_A09: https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities.html
-   OWASP_2021_A06: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Improper input handling is one of the most common weaknesses identified across applications today. Poorly handled input is a leading cause behind critical vulnerabilities that exist in systems and applications.
 	

--- a/site/content/docs/alerts/20018.md
+++ b/site/content/docs/alerts/20018.md
@@ -42,12 +42,10 @@ references:
 cwe: 20
 wasc: 20
 alerttags: 
-   OWASP_2017_A09: https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities.html
-   OWASP_2021_A06: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Improper input handling is one of the most common weaknesses identified across applications today. Poorly handled input is a leading cause behind critical vulnerabilities that exist in systems and applications.
 	

--- a/site/content/docs/alerts/20019.md
+++ b/site/content/docs/alerts/20019.md
@@ -28,11 +28,11 @@ references:
 cwe: 601
 wasc: 38
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 URL redirectors represent common functionality employed by web sites to forward an incoming request to an alternate resource. This can be done for a variety of reasons and is often done to allow resources to be moved within the directory structure and to avoid breaking functionality for users that request the resource at its previous location. URL redirectors may also be used to implement load balancing, leveraging abbreviated URLs or recording outgoing links. It is this last implementation which is often used in phishing attacks as described in the example below. URL redirectors do not necessarily represent a direct security vulnerability but can be abused by attackers trying to social engineer victims into believing that they are navigating to a site other than the true destination.

--- a/site/content/docs/alerts/3.md
+++ b/site/content/docs/alerts/3.md
@@ -13,11 +13,11 @@ references:
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A01
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 URL rewrite is used to track user session ID. The session ID may be disclosed via cross-site referer header. In addition, the session ID might be stored in browser history or server logs.

--- a/site/content/docs/alerts/30001.md
+++ b/site/content/docs/alerts/30001.md
@@ -13,11 +13,11 @@ references:
 cwe: 120
 wasc: 7
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Buffer overflow errors are characterized by the overwriting of memory spaces of the background web process, which should have never been modified intentionally or unintentionally. Overwriting values of the IP (Instruction Pointer), BP (Base Pointer) and other registers causes exceptions, segmentation faults, and other process errors to occur. Usually these errors end execution of the application in an unexpected way. 

--- a/site/content/docs/alerts/30002.md
+++ b/site/content/docs/alerts/30002.md
@@ -13,11 +13,11 @@ references:
 cwe: 134
 wasc: 6
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A Format String error occurs when the submitted data of an input string is evaluated as a command by the application. 

--- a/site/content/docs/alerts/30003.md
+++ b/site/content/docs/alerts/30003.md
@@ -13,11 +13,9 @@ references:
 cwe: 190
 wasc: 3
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 An integer overflow condition exists when an integer, which has not been properly checked from the input stream is used within a compiled program. 

--- a/site/content/docs/alerts/40003.md
+++ b/site/content/docs/alerts/40003.md
@@ -15,11 +15,11 @@ references:
 cwe: 113
 wasc: 25
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Cookie can be set via CRLF injection.  It may also be possible to set arbitrary HTTP response headers. In addition, by carefully crafting the injected response using cross-site script, cache poisoning vulnerability may also exist.

--- a/site/content/docs/alerts/40008.md
+++ b/site/content/docs/alerts/40008.md
@@ -11,11 +11,11 @@ solution: "Identify the cause of the error and fix it.  Do not trust client side
 cwe: 472
 wasc: 20
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A04
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Parameter manipulation caused an error page or Java stack trace to be displayed.  This indicated lack of exception handling and potential areas for further exploit.

--- a/site/content/docs/alerts/40009.md
+++ b/site/content/docs/alerts/40009.md
@@ -14,11 +14,11 @@ references:
 cwe: 97
 wasc: 31
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Certain parameters may cause Server Side Include commands to be executed.  This may allow database connection or arbitrary code to be executed.

--- a/site/content/docs/alerts/40012.md
+++ b/site/content/docs/alerts/40012.md
@@ -37,12 +37,12 @@ references:
 cwe: 79
 wasc: 8
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A07: https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS).html
-code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
-linktext: org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+  - OWASP_2021_A03
+  - OWASP_2017_A07
+code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule2.java
+linktext: org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule2.java
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance. A browser instance can be a standard web browser client, or a browser object embedded in a software product such as the browser within WinAmp, an RSS reader, or an email client. The code itself is usually written in HTML/JavaScript, but may also extend to VBScript, ActiveX, Java, Flash, or any other browser-supported technology.
 When an attacker gets a user's browser to execute his/her code, the code will run within the security context (or zone) of the hosting web site. With this level of privilege, the code has the ability to read, modify and transmit any sensitive data accessible by the browser. A Cross-site Scripted user could have his/her account hijacked (cookie theft), their browser redirected to another location, or possibly shown fraudulent content delivered by the web site they are visiting. Cross-site Scripting attacks essentially compromise the trust relationship between a user and the web site. Applications utilizing browser object instances which load content from the file system may execute code under the local machine zone allowing for system compromise.

--- a/site/content/docs/alerts/40013.md
+++ b/site/content/docs/alerts/40013.md
@@ -23,11 +23,9 @@ references:
 cwe: 384
 wasc: 37
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Session Fixation may be possible. If this issue occurs with a login URL (where the user authenticates themselves to the application), then the URL may be given by an attacker, along with a fixed session id, to a victim, in order to later assume the identity of the victim using the given session id. If the issue occurs with a non-login page, the URL and fixed session id may only be used by an attacker to track an unauthenticated user's actions. If the vulnerability occurs on a cookie field or a form field (POST parameter) rather than on a URL (GET) parameter, then some other vulnerability may also be required in order to set the cookie field on the victim's browser, to allow the vulnerability to be exploited.

--- a/site/content/docs/alerts/40014.md
+++ b/site/content/docs/alerts/40014.md
@@ -37,12 +37,12 @@ references:
 cwe: 79
 wasc: 8
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A07: https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS).html
+  - OWASP_2021_A03
+  - OWASP_2017_A07
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance. A browser instance can be a standard web browser client, or a browser object embedded in a software product such as the browser within WinAmp, an RSS reader, or an email client. The code itself is usually written in HTML/JavaScript, but may also extend to VBScript, ActiveX, Java, Flash, or any other browser-supported technology.
 When an attacker gets a user's browser to execute his/her code, the code will run within the security context (or zone) of the hosting web site. With this level of privilege, the code has the ability to read, modify and transmit any sensitive data accessible by the browser. A Cross-site Scripted user could have his/her account hijacked (cookie theft), their browser redirected to another location, or possibly shown fraudulent content delivered by the web site they are visiting. Cross-site Scripting attacks essentially compromise the trust relationship between a user and the web site. Applications utilizing browser object instances which load content from the file system may execute code under the local machine zone allowing for system compromise.

--- a/site/content/docs/alerts/40015.md
+++ b/site/content/docs/alerts/40015.md
@@ -36,11 +36,9 @@ references:
 cwe: 90
 wasc: 29
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 LDAP Injection may be possible. It may be possible for an attacker to bypass authentication controls, and to view and modify arbitrary data in the LDAP directory. 

--- a/site/content/docs/alerts/40016.md
+++ b/site/content/docs/alerts/40016.md
@@ -15,7 +15,7 @@ wasc: 8
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 N/A

--- a/site/content/docs/alerts/40017.md
+++ b/site/content/docs/alerts/40017.md
@@ -15,7 +15,7 @@ wasc: 8
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 N/A

--- a/site/content/docs/alerts/40018.md
+++ b/site/content/docs/alerts/40018.md
@@ -24,11 +24,11 @@ references:
 cwe: 89
 wasc: 19
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 SQL injection may be possible.

--- a/site/content/docs/alerts/40019.md
+++ b/site/content/docs/alerts/40019.md
@@ -24,11 +24,9 @@ references:
 cwe: 89
 wasc: 19
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
-code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMySqlScanRule.java
-linktext: org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMySqlScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMyqlScanRule.java
+linktext: org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMyqlScanRule.java
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 SQL injection may be possible

--- a/site/content/docs/alerts/40020.md
+++ b/site/content/docs/alerts/40020.md
@@ -24,11 +24,9 @@ references:
 cwe: 89
 wasc: 19
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 SQL injection may be possible

--- a/site/content/docs/alerts/40021.md
+++ b/site/content/docs/alerts/40021.md
@@ -24,11 +24,9 @@ references:
 cwe: 89
 wasc: 19
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 SQL injection may be possible

--- a/site/content/docs/alerts/40022.md
+++ b/site/content/docs/alerts/40022.md
@@ -24,11 +24,9 @@ references:
 cwe: 89
 wasc: 19
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 SQL injection may be possible

--- a/site/content/docs/alerts/40023.md
+++ b/site/content/docs/alerts/40023.md
@@ -14,11 +14,9 @@ references:
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 It may be possible to enumerate usernames, based on differing HTTP responses when valid and invalid usernames are provided. This would greatly increase the probability of success of password brute-forcing attacks against the system. Note that false positives may sometimes be minimised by increasing the 'Attack Strength' Option in ZAP.  Please manually check the 'Other Info' field to confirm if this is actually an issue. 

--- a/site/content/docs/alerts/40024.md
+++ b/site/content/docs/alerts/40024.md
@@ -24,11 +24,9 @@ references:
 cwe: 89
 wasc: 19
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 SQL injection may be possible

--- a/site/content/docs/alerts/40025.md
+++ b/site/content/docs/alerts/40025.md
@@ -17,11 +17,9 @@ references:
 cwe: 200
 wasc: 45
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 

--- a/site/content/docs/alerts/40026.md
+++ b/site/content/docs/alerts/40026.md
@@ -37,12 +37,12 @@ references:
 cwe: 79
 wasc: 8
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A07: https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS).html
+  - OWASP_2021_A03
+  - OWASP_2017_A07
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
 linktext: org/zaproxy/zap/extension/domxss/DomXssScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance. A browser instance can be a standard web browser client, or a browser object embedded in a software product such as the browser within WinAmp, an RSS reader, or an email client. The code itself is usually written in HTML/JavaScript, but may also extend to VBScript, ActiveX, Java, Flash, or any other browser-supported technology.
 When an attacker gets a user's browser to execute his/her code, the code will run within the security context (or zone) of the hosting web site. With this level of privilege, the code has the ability to read, modify and transmit any sensitive data accessible by the browser. A Cross-site Scripted user could have his/her account hijacked (cookie theft), their browser redirected to another location, or possibly shown fraudulent content delivered by the web site they are visiting. Cross-site Scripting attacks essentially compromise the trust relationship between a user and the web site. Applications utilizing browser object instances which load content from the file system may execute code under the local machine zone allowing for system compromise.

--- a/site/content/docs/alerts/40027.md
+++ b/site/content/docs/alerts/40027.md
@@ -24,11 +24,9 @@ references:
 cwe: 89
 wasc: 19
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 SQL injection may be possible

--- a/site/content/docs/alerts/40028.md
+++ b/site/content/docs/alerts/40028.md
@@ -15,11 +15,11 @@ references:
 cwe: 94
 wasc: 14
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/ElmahScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The Error Logging Modules and Handlers (ELMAH [elmah.axd]) HTTP Module was found to be available. This module can leak a significant amount of valuable information.

--- a/site/content/docs/alerts/40029.md
+++ b/site/content/docs/alerts/40029.md
@@ -15,11 +15,9 @@ references:
 cwe: 215
 wasc: 13
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The ASP.NET Trace Viewer (trace.axd) was found to be available. This component can leak a significant amount of valuable information.

--- a/site/content/docs/alerts/40032.md
+++ b/site/content/docs/alerts/40032.md
@@ -13,11 +13,11 @@ references:
 cwe: 94
 wasc: 14
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HtAccessScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/HtAccessScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 htaccess files can be used to alter the configuration of the Apache Web Server software to enable/disable additional functionality and features that the Apache Web Server software has to offer. 

--- a/site/content/docs/alerts/40033.md
+++ b/site/content/docs/alerts/40033.md
@@ -15,11 +15,9 @@ references:
 cwe: 943
 wasc: 19
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 MongoDB query injection may be possible.

--- a/site/content/docs/alerts/40034.md
+++ b/site/content/docs/alerts/40034.md
@@ -14,11 +14,9 @@ references:
 cwe: 215
 wasc: 13
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/EnvFileScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/EnvFileScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 One or more .env files seems to have been located on the server. These files often expose infrastructure or administrative account credentials, API or APP keys, or other sensitive configuration information. 

--- a/site/content/docs/alerts/40035.md
+++ b/site/content/docs/alerts/40035.md
@@ -13,11 +13,9 @@ references:
 cwe: 538
 wasc: 13
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A sensitive file was identified as accessible or available. This may leak administrative, configuration, or credential information which can be leveraged by a malicious individual to further attack the system or conduct social engineering efforts.

--- a/site/content/docs/alerts/40038.md
+++ b/site/content/docs/alerts/40038.md
@@ -13,11 +13,9 @@ references:
    - https://i.blackhat.com/us-18/Wed-August-8/us-18-Orange-Tsai-Breaking-Parser-Logic-Take-Your-Path-Normalization-Off-And-Pop-0days-Out-2.pdf
    - https://www.contextis.com/en/blog/server-technologies-reverse-proxy-bypass
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ForbiddenBypassScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesAlpha/ForbiddenBypassScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Bypassing 403 endpoints may be possible, the scan rule sent a payload that caused the response to be accessible (status code 200).

--- a/site/content/docs/alerts/40039.md
+++ b/site/content/docs/alerts/40039.md
@@ -12,11 +12,9 @@ references:
    - https://blogs.akamai.com/2017/03/on-web-cache-deception-attacks.html
    - https://www.netsparker.com/web-vulnerability-scanner/vulnerabilities/web-cache-deception/
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/WebCacheDeceptionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesAlpha/WebCacheDeceptionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Web cache deception may be possible. It may be possible for unauthorised user to view sensitive data on this page.

--- a/site/content/docs/alerts/40040-1.md
+++ b/site/content/docs/alerts/40040-1.md
@@ -14,11 +14,9 @@ references:
 cwe: 942
 wasc: 14
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Cross-Origin Resource Sharing (CORS) is an HTTP-header based mechanism that allows a server to indicate any other origins (domain, scheme, or port) than its own from which a browser should permit loading of resources. It relaxes the Same-Origin Policy (SOP).

--- a/site/content/docs/alerts/40040-2.md
+++ b/site/content/docs/alerts/40040-2.md
@@ -14,12 +14,10 @@ references:
 cwe: 942
 wasc: 14
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This CORS misconfiguration could allow an attacker to perform AJAX queries to the vulnerable website from a malicious page loaded by the victim's user agent.
 In order to perform authenticated AJAX queries, the server must specify the header "Access-Control-Allow-Credentials: true" and the "Access-Control-Allow-Origin" header must be set to null or the malicious page's domain. Even if this misconfiguration doesn't allow authenticated AJAX requests, unauthenticated sensitive content can still be accessed (e.g intranet websites).

--- a/site/content/docs/alerts/40040-3.md
+++ b/site/content/docs/alerts/40040-3.md
@@ -14,12 +14,10 @@ references:
 cwe: 942
 wasc: 14
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This CORS misconfiguration could allow an attacker to perform AJAX queries to the vulnerable website from a malicious page loaded by the victim's user agent.
 In order to perform authenticated AJAX queries, the server must specify the header "Access-Control-Allow-Credentials: true" and the "Access-Control-Allow-Origin" header must be set to null or the malicious page's domain. Even if this misconfiguration doesn't allow authenticated AJAX requests, unauthenticated sensitive content can still be accessed (e.g intranet websites).

--- a/site/content/docs/alerts/40040.md
+++ b/site/content/docs/alerts/40040.md
@@ -17,6 +17,6 @@ alerts:
       name: CORS Misconfiguration
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java
 linktext: "org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java"
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---

--- a/site/content/docs/alerts/40042.md
+++ b/site/content/docs/alerts/40042.md
@@ -13,8 +13,8 @@ references:
 cwe: 215
 wasc: 13
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+  - OWASP_2021_A01
+  - OWASP_2017_A05
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRule.java
 date: 2021-10-14 08:21:59.220Z

--- a/site/content/docs/alerts/41.md
+++ b/site/content/docs/alerts/41.md
@@ -14,11 +14,9 @@ references:
 cwe: 541
 wasc: 34
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The source code for the current page was disclosed by the web server

--- a/site/content/docs/alerts/42.md
+++ b/site/content/docs/alerts/42.md
@@ -14,11 +14,9 @@ references:
 cwe: 541
 wasc: 34
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The source code for the current page was disclosed by the web server

--- a/site/content/docs/alerts/43.md
+++ b/site/content/docs/alerts/43.md
@@ -34,12 +34,10 @@ references:
 cwe: 541
 wasc: 33
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The Path Traversal attack technique allows an attacker access to files, directories, and commands that potentially reside outside the web document root directory. An attacker may manipulate a URL in such a way that the web site will execute or reveal the contents of arbitrary files anywhere on the web server. Any device that exposes an HTTP-based interface is potentially vulnerable to Path Traversal.
 

--- a/site/content/docs/alerts/6.md
+++ b/site/content/docs/alerts/6.md
@@ -34,12 +34,12 @@ references:
 cwe: 22
 wasc: 33
 alerttags: 
-   OWASP_2021_A01: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-   OWASP_2017_A05: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+  - OWASP_2021_A01
+  - OWASP_2017_A05
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The Path Traversal attack technique allows an attacker access to files, directories, and commands that potentially reside outside the web document root directory. An attacker may manipulate a URL in such a way that the web site will execute or reveal the contents of arbitrary files anywhere on the web server. Any device that exposes an HTTP-based interface is potentially vulnerable to Path Traversal.
 

--- a/site/content/docs/alerts/7.md
+++ b/site/content/docs/alerts/7.md
@@ -36,12 +36,12 @@ references:
 cwe: 98
 wasc: 5
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Remote File Include (RFI) is an attack technique used to exploit "dynamic file include" mechanisms in web applications. When web applications take user input (URL, parameter value, etc.) and pass them into file include commands, the web application might be tricked into including remote files with malicious code.
 

--- a/site/content/docs/alerts/90001.md
+++ b/site/content/docs/alerts/90001.md
@@ -13,11 +13,11 @@ references:
 cwe: 642
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A04
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The response at the following URL contains a ViewState value that has no cryptographic protections.

--- a/site/content/docs/alerts/90002.md
+++ b/site/content/docs/alerts/90002.md
@@ -10,11 +10,11 @@ solution: "Deserialization of untrusted data is inherently dangerous and should 
 references:
    - https://www.oracle.com/technetwork/java/seccodeguide-139067.html#8
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A08: https://owasp.org/www-project-top-ten/2017/A8_2017-Insecure_Deserialization.html
+  - OWASP_2021_A04
+  - OWASP_2017_A08
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Java Serialization seems to be in use. If not correctly validated, an attacker can send a specially crafted object. This can lead to a dangerous "Remote Code Execution". A magic sequence identifying JSO has been detected (Base64: rO0AB, Raw: 0xac, 0xed, 0x00, 0x05).

--- a/site/content/docs/alerts/90003.md
+++ b/site/content/docs/alerts/90003.md
@@ -10,11 +10,11 @@ solution: "Provide a valid integrity attribute to the tag."
 references:
    - https://developer.mozilla.org/en/docs/Web/Security/Subresource_Integrity
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The integrity attribute is missing on a script or link tag served by an external server. The integrity tag prevents an attacker who have gained access to this server from injecting a malicious content. 

--- a/site/content/docs/alerts/90004-1.md
+++ b/site/content/docs/alerts/90004-1.md
@@ -16,11 +16,11 @@ references:
 cwe: 693
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A04
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Cross-Origin-Resource-Policy header is an opt-in header designed to counter side-channels attacks like Spectre. Resource should be specifically set as shareable amongst different origins.

--- a/site/content/docs/alerts/90004-2.md
+++ b/site/content/docs/alerts/90004-2.md
@@ -14,11 +14,11 @@ references:
 cwe: 693
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A04
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Cross-Origin-Embedder-Policy header is a response header that prevents a document from loading any cross-origin resources that don't explicitly grant the document permission (using CORP or CORS).

--- a/site/content/docs/alerts/90004-3.md
+++ b/site/content/docs/alerts/90004-3.md
@@ -15,11 +15,11 @@ references:
 cwe: 693
 wasc: 14
 alerttags: 
-   OWASP_2021_A04: https://owasp.org/Top10/A04_2021-Insecure_Design/
-   OWASP_2017_A03: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+  - OWASP_2021_A04
+  - OWASP_2017_A03
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Cross-Origin-Opener-Policy header is a response header that allows a site to control if others included documents share the same browsing context. Sharing the same browsing context with untrusted documents might lead to data leak.

--- a/site/content/docs/alerts/90004.md
+++ b/site/content/docs/alerts/90004.md
@@ -17,6 +17,6 @@ alerts:
       name: Insufficient Site Isolation Against Spectre Vulnerability
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
 linktext: "org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java"
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---

--- a/site/content/docs/alerts/90011.md
+++ b/site/content/docs/alerts/90011.md
@@ -15,8 +15,8 @@ wasc: 15
 alerttags: 
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This check identifies responses where the HTTP Content-Type header declares a charset different from the charset defined by the body of the HTML or XML. When there's a charset mismatch between the HTTP header and content body Web browsers can be forced into an undesirable content-sniffing mode to determine the content's correct character set.
 

--- a/site/content/docs/alerts/90017.md
+++ b/site/content/docs/alerts/90017.md
@@ -13,11 +13,9 @@ references:
 cwe: 91
 wasc: 23
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XsltInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/XsltInjectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Injection using XSL transformations may be possible, and may allow an attacker to read system information, read and write files, or execute arbitrary code.

--- a/site/content/docs/alerts/90018.md
+++ b/site/content/docs/alerts/90018.md
@@ -24,8 +24,8 @@ references:
 cwe: 89
 wasc: 19
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
 date: 2021-10-14 08:21:59.220Z

--- a/site/content/docs/alerts/90019.md
+++ b/site/content/docs/alerts/90019.md
@@ -16,11 +16,11 @@ references:
 cwe: 94
 wasc: 20
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A code injection may be possible including custom code that will be evaluated by the scripting engine

--- a/site/content/docs/alerts/90020.md
+++ b/site/content/docs/alerts/90020.md
@@ -43,11 +43,11 @@ references:
 cwe: 78
 wasc: 31
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Attack technique used for unauthorized execution of operating system commands. This attack is possible when an application accepts untrusted input to build operating system commands in an insecure manner involving improper data sanitization, and/or improper calling of external programs.

--- a/site/content/docs/alerts/90021.md
+++ b/site/content/docs/alerts/90021.md
@@ -16,12 +16,10 @@ references:
 cwe: 643
 wasc: 39
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 XPath Injection is an attack technique used to exploit applications that construct XPath (XML Path Language) queries from user-supplied input to query or navigate XML documents. It can be used directly by an application to query an XML document, as part of a larger operation such as applying an XSLT transformation to an XML document, or applying an XQuery to an XML document. The syntax of XPath bears some resemblance to an SQL query, and indeed, it is possible to form SQL-like queries on an XML document using XPath.
 

--- a/site/content/docs/alerts/90022.md
+++ b/site/content/docs/alerts/90022.md
@@ -11,11 +11,11 @@ solution: "Review the source code of this page. Implement custom error pages. Co
 cwe: 200
 wasc: 13
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This page contains an error/warning message that may disclose sensitive information like the location of the file that produced the unhandled exception. This information can be used to launch further attacks against the web application. The alert could be a false positive if the error message is found inside a documentation page.

--- a/site/content/docs/alerts/90023.md
+++ b/site/content/docs/alerts/90023.md
@@ -13,12 +13,10 @@ references:
 cwe: 611
 wasc: 43
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A04: https://owasp.org/www-project-top-ten/2017/A4_2017-XML_External_Entities_(XXE).html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 This technique takes advantage of a feature of XML to build documents dynamically at the time of processing. An XML message can either provide data explicitly or by pointing to an URI where the data exists. In the attack technique, external entities may replace the entity value with malicious data, alternate referrals or may compromise the security of the data the server/XML application has access to.
 	Attackers may also use External Entities to have the web services server download malicious code or content to the server for use in secondary or follow on attacks.

--- a/site/content/docs/alerts/90024.md
+++ b/site/content/docs/alerts/90024.md
@@ -16,11 +16,9 @@ references:
 cwe: 209
 wasc: 20
 alerttags: 
-   OWASP_2021_A02: https://owasp.org/Top10/A02_2021-Cryptographic_Failures/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOracleScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/PaddingOracleScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 By manipulating the padding on an encrypted string, an attacker is able to generate an error message that indicates a likely 'padding oracle' vulnerability. Such a vulnerability can affect any application or framework that uses encryption improperly, such as some versions of ASP.net, Java Server Faces, and Mono. An attacker may exploit this issue to decrypt data and recover encryption keys, potentially viewing and modifying confidential data. This rule should detect the MS10-070 padding oracle vulnerability in ASP.net if CustomErrors are enabled for that.

--- a/site/content/docs/alerts/90025.md
+++ b/site/content/docs/alerts/90025.md
@@ -14,11 +14,9 @@ references:
 cwe: 917
 wasc: 20
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The software constructs all or part of an expression language (EL) statement in a Java Server Page (JSP) using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended EL statement before it is executed. In certain versions of Spring 3.0.5 and earlier, there was a vulnerability (CVE-2011-2730) in which Expression Language tags would be evaluated twice, which effectively exposed any application to EL injection. However, even for later versions, this weakness is still possible depending on configuration.

--- a/site/content/docs/alerts/90026.md
+++ b/site/content/docs/alerts/90026.md
@@ -11,11 +11,11 @@ solution: "If not required, the SOAPAction attribute should be disabled. If need
 references:
    - http://www.ws-attacks.org/index.php/SOAPAction_Spoofing
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRule.java
 linktext: org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 An unintended SOAP operation was executed by the server.

--- a/site/content/docs/alerts/90027.md
+++ b/site/content/docs/alerts/90027.md
@@ -13,11 +13,9 @@ references:
 cwe: 200
 wasc: 45
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Repeated GET requests: drop a different cookie each time, followed by normal request with all cookies to stabilize session, compare responses against original baseline GET. This can reveal areas where cookie based authentication/attributes are not actually enforced.

--- a/site/content/docs/alerts/90028.md
+++ b/site/content/docs/alerts/90028.md
@@ -13,12 +13,10 @@ references:
 cwe: 200
 wasc: 45
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The most common methodology for attackers is to first footprint the target's web presence and enumerate as much information as possible. With this information, the attacker may develop an accurate attack scenario, which will effectively exploit a vulnerability in the software type/version being utilized by the target host.
 

--- a/site/content/docs/alerts/90029.md
+++ b/site/content/docs/alerts/90029.md
@@ -11,11 +11,11 @@ solution: "Use a detailed description of SOAP attributes in the WSDL file."
 references:
    - http://www.ws-attacks.org/index.php/XML_Injection
 alerttags: 
-   OWASP_2021_A03: https://owasp.org/Top10/A03_2021-Injection/
-   OWASP_2017_A01: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+  - OWASP_2021_A03
+  - OWASP_2017_A01
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRule.java
 linktext: org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Some XML injected code has been interpreted by the server.

--- a/site/content/docs/alerts/90030.md
+++ b/site/content/docs/alerts/90030.md
@@ -10,11 +10,11 @@ solution: "Make your WSDL files visible only for technical issues (ex: testing p
 references:
    - No references.
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A05
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
 linktext: org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 A WSDL File has been detected.

--- a/site/content/docs/alerts/90033.md
+++ b/site/content/docs/alerts/90033.md
@@ -15,11 +15,11 @@ references:
 cwe: 565
 wasc: 15
 alerttags: 
-   OWASP_2021_A08: https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+  - OWASP_2021_A08
+  - OWASP_2017_A06
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
 linktext: org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. www.nottrusted.com, or loosely scoped to a parent domain e.g. nottrusted.com. In the latter case, any subdomain of nottrusted.com can access the cookie. Loosely scoped cookies are common in mega-applications like google.com and live.com. Cookies set from a subdomain like app.foo.bar are transmitted only to that domain by the browser. However, cookies scoped to a parent-level domain may be transmitted to the parent, or any subdomain of the parent.

--- a/site/content/docs/alerts/90034.md
+++ b/site/content/docs/alerts/90034.md
@@ -11,12 +11,10 @@ solution: "Do not trust any user data in NGINX configs. In this case it is proba
 references:
    - https://www.nginx.com/blog/trust-no-one-perils-of-trusting-user-input/
 alerttags: 
-   OWASP_2021_A05: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
-   OWASP_2017_A06: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
 code: https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRule.java
 linktext: org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRule.java
-date: 2021-10-14 08:21:59.220Z
-lastmod: 2021-10-14 08:21:59.220Z
+date: 2021-11-30 12:22:14.656Z
+lastmod: 2021-11-30 12:22:14.656Z
 ---
 The Cloud Metadata Attack attempts to abuse a misconfigured NGINX server in order to access the instance metadata maintained by cloud service providers such as AWS, GCP and Azure.
 All of these providers provide metadata via an internal unroutable IP address '169.254.169.254' - this can be exposed by incorrectly configured NGINX servers and accessed by using this IP address in the Host header field.

--- a/site/data/alerttags.yml
+++ b/site/data/alerttags.yml
@@ -1,0 +1,42 @@
+OWASP_2017_A01:
+  link: https://owasp.org/www-project-top-ten/2017/A1_2017-Injection.html
+
+OWASP_2017_A03:
+  link: https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html
+
+OWASP_2017_A05:
+  link: https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+
+OWASP_2017_A06:
+  link: https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html
+
+OWASP_2017_A07:
+  link: https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS).html
+
+OWASP_2017_A08:
+  link: https://owasp.org/www-project-top-ten/2017/A8_2017-Insecure_Deserialization.html
+
+OWASP_2017_A09:
+  link: https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities.html
+
+OWASP_2021_A01:
+  link: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+
+OWASP_2021_A02:
+  link: https://owasp.org/Top10/A02_2021-Cryptographic_Failures/
+
+OWASP_2021_A03:
+  link: https://owasp.org/Top10/A03_2021-Injection/
+
+OWASP_2021_A04:
+  link: https://owasp.org/Top10/A04_2021-Insecure_Design/
+
+OWASP_2021_A05:
+  link: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
+
+OWASP_2021_A06:
+  link: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
+
+OWASP_2021_A08:
+  link: https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/
+

--- a/site/layouts/alert/single.html
+++ b/site/layouts/alert/single.html
@@ -68,8 +68,8 @@
                 <strong>Tags</strong>
               </td>
               <td>
-              {{ range $tagkey, $tagvalue := .Params.alerttags }}
-              	<a href="{{ $tagvalue }}">{{ upper $tagkey }}</a><br>
+              {{ range $tag := .Params.alerttags }}
+              	<a href="/alerttags/{{ lower $tag }}">{{ upper $tag }}</a><br>
               {{ end }}
               </td>
             </tr>

--- a/site/layouts/alerttags/list.html
+++ b/site/layouts/alerttags/list.html
@@ -1,0 +1,50 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
+{{ define "main" }}
+<section class="bolt-header">
+  <div class="wrapper py-20">
+    {{ if eq .Title "Alerttags" }}
+      <h1 class="text--white">Alert Tags</h1>
+    {{ else }}
+      <h1 class="text--white">Alert Tag:  {{ .Title }}</h1>
+    {{ end }}
+  </div>
+</section>
+  <div class="wrapper py-70">
+    <header class="breadcrumbs">
+        <a href="/alerttags/">Alert Tags</a> &gt;
+        {{ if ne .Title "Alerttags" }}
+        <a href="/alerttags/{{ lower .Title }}">{{ .Title }}</a>
+        {{ end }}
+    </header>
+   {{ .Content }}
+
+    {{ if eq .Title "Alerttags" }}
+      All of the defined Alert Tags:
+    {{ else }}
+      {{ $alerttag := index $.Site.Data.alerttags .Title }}
+      {{ if $alerttag.link }}
+        <h4><a href="{{ $alerttag.link }}">{{ $alerttag.link }}</a></h4>
+      {{ else }}
+        <h4>{{ .Title }}</h4>
+      {{ end }}
+      All of the alerts which use this tag:
+    {{ end }}
+
+   <div class="flex latest-versions">
+      <table data-sort-filter>
+         <thead>
+            <tr>
+               <th>Search</th>
+            </tr>
+         </thead>
+         <tbody>
+            {{ range .Pages }}
+               <tr>
+                  <td><a href="{{ .Permalink }}">{{ .Title }}</a></td>
+               </tr>
+            {{ end }}
+         </tbody>
+      </table>
+   </div>
+  </div>
+{{ end }} 


### PR DESCRIPTION
Adds pages for all of the alert tags defined - these link to all of the alerts that use them.
If the tags have links then the pages will include them, if not then they wont.

The script https://github.com/zaproxy/zap-admin/blob/master/scripts/generate_alert_pages.js required changes, I'll submit another PR for that.

I'm sure it could be prettier, but its a start...

Top page

![Screenshot 2021-11-30 at 14-51-56 OWASP ZAP – Alerttags](https://user-images.githubusercontent.com/1081115/144070129-d9857b41-568a-470c-96e0-b678213de46e.png)

Example specific page

![Screenshot 2021-11-30 at 14-52-05 OWASP ZAP – OWASP_2017_A01](https://user-images.githubusercontent.com/1081115/144070168-79cf2c4f-26ad-40cc-a523-521fe8ff1c3a.png)

The alert pages look the same but the tags link initially to our pages instead of the external link.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
