### PR TITLE
Add 3rd Party Package Maintenance page

### DIFF
--- a/site/content/3rd-party-package-maintenance.md
+++ b/site/content/3rd-party-package-maintenance.md
@@ -1,0 +1,22 @@
+---
+type: page
+title: 3rd Party Package Maintenance
+EditableContent: true
+---
+
+ZAP is re-packaged by a number of 3rd parties.
+
+This page lists all of the ones we are aware of along with details of how we notify them of new ZAP releases.
+
+To be added to this page submit a PR via the "Edit on GitHub" link in the footer.
+
+| Package      | Instructions                                                                                              |
+|:-------------|:----------------------------------------------------------------------------------------------------------|
+| BackBox      | Maintained by [@raffaele_forte](https://twitter.com/raffaele_forte)                                       |
+| Brew         | Submit a PR on [owasp-zap-rb](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/owasp-zap.rb)   |
+| Chocolatey   | Raise an issue on [chocolatey-packages](https://github.com/jtcmedia/chocolatey-packages)                  |
+| Flathub      | Submit a PR on [ZAP](https://github.com/flathub/org.zaproxy.ZAP)                                          |
+| FreeBSD      | Email jacardenasm@gmail.com                                                                               |
+| Kali         | Raise a new issue on the [Kali Linux Bug Tracker](https://bugs.kali.org/my_view_page.php)                 |
+| Linux repos  | Maintained by [Cabelo](https://en.opensuse.org/User:Cabelo) on behalf of the ZAP Core Team                |
+| Scoop        | Submit a PR on [zaproxy.json](https://github.com/ScoopInstaller/Extras/blob/master/bucket/zaproxy.json)   |

--- a/site/data/download/g_latest.yml
+++ b/site/data/download/g_latest.yml
@@ -2,11 +2,13 @@
 ---
 title: Latest Versions
 info:
-- We maintain a page containing XML with links to the latest ZAP release files
-- You can use this to automatically pull down the latest ZAP release for the platform you need.
+- We maintain a set of pages containing XML with links to the latest ZAP release files
+- You can use them to automatically pull down the latest ZAP release for the platform you need.
 - ZAP uses similar URLs when checking for updates.
-- These are version specific and define the add-on on the ZAP Marketplace for that release stream.
+- The file [https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml](https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml) is version independent and always points to the latest release.
+- There are also version specific files that define the add-ons on the ZAP Marketplace for that release stream.
 - The 2.11 release stream uses [https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-2.11.xml](https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-2.11.xml)
 - The development code uses [https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml](https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml)
 - These files are usually the same, but it does allow us to release add-ons which depend on core features which have been added since the current stable release.
+- See [3rd Party Package Maintenance](/3rd-party-package-maintenance) for details of how 3rd party packages which wrap ZAP are maintained.
 illustration:  version-bot.svg


### PR DESCRIPTION
My plan is to tell the relevant people on this page about it when we tell them about 2.11.1

![Screenshot 2021-12-10 at 13-47-03 OWASP ZAP – 3rd Party Package Maintenance](https://user-images.githubusercontent.com/1081115/145583992-09464257-a4dd-4999-80b5-0f07d95d551a.png)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
