### PR TITLE
chore: Adjust webpack build config

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -10,7 +10,7 @@ module.exports = merge(common, {
 
   output: {
     filename: "[name].js",
-    chunkFilename: "[id].css"
+    chunkFilename: "[id].js"
   },
 
   devServer: {    

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -9,11 +9,12 @@ module.exports = merge(common, {
   mode: "production",
 
   output: {
-    filename: "[name].[hash:5].js",
-    chunkFilename: "[id].[hash:5].css"
+    filename: "[name].[contenthash:6].js",
+    chunkFilename: "[id].[contenthash:6].js"
   },
 
   optimization: {
+  runtimeChunk: 'single',
     minimizer: [
       new TerserPlugin({
         parallel: true,
@@ -23,8 +24,8 @@ module.exports = merge(common, {
       }),
 
       new MiniCssExtractPlugin({
-        filename: "[name].[hash:5].css",
-        chunkFilename: "[id].[hash:5].css"
+        filename: "[name].[contenthash:6].css",
+        chunkFilename: "[id].[contenthash:6].css"
       }),
 
       new OptimizeCSSAssetsPlugin({})


### PR DESCRIPTION
Adjust webpack.prod.js to use contenthash:6 vs hash:5 for filenames, and split the runtime chunk into a separate file. Also adjust `webpack.*.js` so that the chunkFilename for js files is js not css.

`main.*.js` and `main.*.css` seem to be consistent between builds. `runtime.*.js` is always unique, however does not seem to actually be referenced in site content. So while that one file may always get updated at least not every single file for the site will have new js/css references.

```
assets by path *.js 46.1 KiB
  asset main.20998b.js 33.7 KiB [emitted] [immutable] [minimized] (name: main)
  asset runtime.5492d1.js 12.4 KiB [emitted] [immutable] [minimized] (name: runtime)
asset main.ac09b6.css 23.1 KiB [emitted] [immutable] (name: main)
asset .keep 0 bytes [emitted] [from: src/fonts/.keep] [copied]
Entrypoint main 69.2 KiB = runtime.5492d1.js 12.4 KiB main.ac09b6.css 23.1 KiB main.20998b.js 33.7 KiB
```

Note I could not find a way to run a local server with the prod config. This is simply based on `npm run build`, which guilds things but doesn't actually start a server.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
