### PR TITLE
chore: Adjust webpack prod build

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -14,7 +14,6 @@ module.exports = merge(common, {
   },
 
   optimization: {
-  runtimeChunk: 'single',
     minimizer: [
       new TerserPlugin({
         parallel: true,


### PR DESCRIPTION
Don't split runtime. Unfortunately this means the JS will always be different, but it lets things work once again. After the previous PR that keeps css more consistent it'll still be half the amount of change per PR.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
