### PR TITLE
chore: Use title caps on Download Now button

### DIFF
--- a/site/layouts/partials/homepage/hero.html
+++ b/site/layouts/partials/homepage/hero.html
@@ -16,7 +16,7 @@
               </hgroup>
 
               <a href="/getting-started/" class="button button--blue">Quick Start Guide</a>
-              <a href="/download/" class="button button--orange">Download now</a>
+              <a href="/download/" class="button button--orange">Download Now</a>
             </div>
             <div class="homepage-hero__item-image ml-40">
                 {{ $svg := (printf "%s%s" "svg/homepage/hero/" .image ) }}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7570458/146942964-b37dcb88-a14b-421e-89d8-1b85fbda1155.png)

After:
![image](https://user-images.githubusercontent.com/7570458/146942993-73551df4-1ed5-4d01-8cf1-57f096661c18.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
