### PR TITLE
Remove HMR when building for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:preview": "npm run build:webpack && npm run build:hugo:preview",
     "build:hugo": "hugo -d ../dist -s site -v",
     "build:hugo:preview": "npm run build:hugo -- -D -F",
-    "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.prod.js --hot"
+    "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.prod.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Remove the flag that enables hot module replacement which was causing
the JavaScript file to always be different (and hot replacement is not
needed for the production site).