### PR TITLE
Auth docs - prev/next links

### DIFF
--- a/site/content/docs/authentication/concepts.md
+++ b/site/content/docs/authentication/concepts.md
@@ -50,3 +50,5 @@ If it appears that the user is no longer authenticated during an authenticated s
 
 [^1]: [OWASP Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)
 [^2]: [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+
+{{<prevnext prevUrl="../manual-auth/" prevTitle="Manual authentication" nextUrl="../handling-auth-yourself/" nextTitle="Handling authentication yourself in automation">}}

--- a/site/content/docs/authentication/handling-auth-yourself.md
+++ b/site/content/docs/authentication/handling-auth-yourself.md
@@ -52,3 +52,5 @@ You can perform authenticated scans while still handling authentication yourself
 ZAP will maintain statistics based on the Verification Strategy which will allow you to see if authentication appears to be working.
 
 For more details see Verification strategies (Coming Soon).
+
+{{<prevnext prevUrl="../concepts/" prevTitle="ZAP authentication concepts" nextTitle="Session Handling (coming soon)">}}

--- a/site/content/docs/authentication/make-your-life-easier.md
+++ b/site/content/docs/authentication/make-your-life-easier.md
@@ -38,3 +38,5 @@ If you are testing your own app then seriously consider what options you have yo
 Although you probably want to use authentication in automation it is still much easier to test it in the ZAP Desktop.
 
 You will be able to see the requests and responses sent through ZAP and be able to change them on the fly in order to see what works and what does not work.
+
+{{<prevnext nextUrl="../manual-auth/" nextTitle="Manual authentication">}}

--- a/site/content/docs/authentication/manual-auth.md
+++ b/site/content/docs/authentication/manual-auth.md
@@ -47,3 +47,5 @@ ZAP tools like the spiders and active scanner typically replay the previously re
 Defining a session as active will ensure that these tools use the right cookie for the active session.
 
 Using an active session also allows you to switch quickly and easily between different app sessions as part of your manual testing.
+
+{{<prevnext prevUrl="../make-your-life-easier/" prevTitle="How to make your life easier" nextUrl="../concepts/" nextTitle="ZAP authentication concepts">}}

--- a/site/content/zap-in-ten.md
+++ b/site/content/zap-in-ten.md
@@ -59,5 +59,3 @@ links:
 
 ---
 A series of short videos (~10 mins each) about different ZAP features produced in conjunction with [All Day DevOps](https://www.alldaydevops.com/).
-Also available on https://www.alldaydevops.com/zap-in-ten
-

--- a/site/layouts/shortcodes/prevnext.html
+++ b/site/layouts/shortcodes/prevnext.html
@@ -1,0 +1,10 @@
+<div class="next-content bg--blue-lightest p-10">
+    {{ if .Get "prevUrl" }}
+      Previous <a class="previous" href='{{.Get "prevUrl"}}'> {{.Get "prevTitle"}}</a>
+    {{ end }}
+    {{ if .Get "nextUrl" }}
+      Next <a class="next" href='{{.Get "nextUrl"}}'> {{.Get "nextTitle"}}</a>
+    {{ else if .Get "nextTitle" }}
+      Next {{.Get "nextTitle"}}
+    {{ end }}
+</div>


### PR DESCRIPTION
Add previous / next links to the auth docs as they are designed to be read in order.
The links are maintained manually - I'm sure hugo has a cleaver way of doing this automatically but I couldnt work out how, and these pages wont change often.
Also removed the ZAP in Ten link which no longer works.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>
