### PR TITLE
[Docs] Fix Broken Link 

### DIFF
--- a/site/content/docs/contribute/core-team.md
+++ b/site/content/docs/contribute/core-team.md
@@ -12,7 +12,7 @@ It is also a team - we work together in a collaborative way to make ZAP a better
 Decisions are made as a group, no one person makes the final decision - either we all agree or we work out a way to ensure everyone is happy with a given approach.
 
 The Core Team communicates very regularly in [IRC](https://web.libera.chat/#zaproxy) and have a 45 min weekly meeting on Fridays at 15:00 UTC.
-This meeting is open to anyone who is interested in ZAP development - [get in contact]((mailto:zaproxy-admin@googlegroups.com)) with us to receive an invite.
+This meeting is open to anyone who is interested in ZAP development - [get in contact](mailto:zaproxy-admin@googlegroups.com) with us to receive an invite.
 
 We are always looking for new people to join the Core Team, but only people who have significantly contributed to ZAP and work with us to make ZAP a better project will be invited to join.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/zaproxy/zaproxy-website/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
The markdown formatting for external link is incorrect. This is the only occurrence I could find on the website of this specific formatting issue.

The **get in contact** hyperlink leads to a 404 page, instead of redirecting to an email client.

[Issue Page](https://www.zaproxy.org/docs/contribute/core-team/)

Signed-off-by: Prince Mendiratta <prince.mendi@gmail.com>