### PR TITLE
Restore linkify protocol

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -5,6 +5,11 @@ title: "OWASP ZAP"
 enableEmoji: true
 summaryLength: 48
 
+markup:
+  goldmark:
+    extensions:
+      linkifyProtocol: http
+
 taxonomies:
   tag: "tags"
   successtag: "successtags"


### PR DESCRIPTION
Keep using `http` by default, not all sites we link to support HTTPS.