### PR TITLE
chore: Disable Hugo Generator Meta Tag

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -4,6 +4,7 @@ languageLang: "en"
 title: "OWASP ZAP"
 enableEmoji: true
 summaryLength: 48
+disableHugoGeneratorInject: true
 
 markup:
   goldmark:


### PR DESCRIPTION
No point PRing content just to update this tag every time hugo-bin gets upgraded by dependabot.

https://github.com/gohugoio/hugo/issues/2850#issuecomment-269571942

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
