### PR TITLE
Fixed wrong API end point reference

### DIFF
--- a/site/content/docs/desktop/addons/automation-framework/job-delay.md
+++ b/site/content/docs/desktop/addons/automation-framework/job-delay.md
@@ -16,7 +16,7 @@ The conditions supported are:
 
 * The creation of the file given by the optional fileName parameter
 * Calling the static method: `org.zaproxy.addon.automation.jobs.DelayJob.setEndJob(true);`
-* Calling the API end point: `authentication / action / endDelayJob`
+* Calling the API end point: `automation / action / endDelayJob`
 
 ## YAML
 


### PR DESCRIPTION
**- Summary**

I came across this description how to call the endDelay endpoint while browsing the docs.  
Guess it should be "automation" instead of "authentication".

**- Test plan**

The URL http://zap/UI/automation/action/endDelayJob/ exists, while http://zap/UI/authentication/action/endDelayJob/ does not.

**- Description for the changelog**

Exchanged the string "authentication" for "automation". That's it.

