### PR TITLE
Replace broken link

### DIFF
--- a/site/data/evangelists.yaml
+++ b/site/data/evangelists.yaml
@@ -124,7 +124,7 @@
   has_talks: Y
   has_training: Y
   notes: >
-    Founder of <a href="http://www.mmeit.be/bwapp/" rel="nofollow">bWAPP</a>
+    Founder of <a href="https://www.mmesec.com/software/web-security-testing-framework" rel="nofollow">bWAPP</a>
     'Training: Attacking &amp; Defending Web Apps with bWAPP'
 
 - name: Mark Goodwin


### PR DESCRIPTION
Replace link that no longer resolves in the Evangelists page, reported
by the Broken Link Check action.

---
https://github.com/zaproxy/zaproxy-website/runs/7143548570?check_suite_focus=true