### PR TITLE
Note that Firefox and Chrome do not proxy to localhost by default.

### DIFF
--- a/site/content/faq/how-do-you-configure-zap-to-test-an-application-on-localhost.md
+++ b/site/content/faq/how-do-you-configure-zap-to-test-an-application-on-localhost.md
@@ -16,4 +16,7 @@ Proxies](/docs/desktop/ui/dialogs/options/localproxy/) screen, remember to chang
 browser's proxy settings as well: [Configuring Proxies](/docs/desktop/start/proxies/).
 
 You also need to check that you have not configured your browser to ignore
-your configured proxy (ZAP) for localhost.
+your configured proxy (ZAP) for localhost. Note that Firefox (>= version 67)
+and Chrome (>= version 72) by default do not proxy to localhost.
+[Configuring Proxies](/docs/desktop/start/proxies/) explains how to reconfigure
+them to proxy to localhost.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/zaproxy/zaproxy-website/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Explain that Firefox (>= version 67) and Chrome (>= version 72) by default do not proxy to localhost and where to find instructions to reconfigure them.