### PR TITLE
Add Roles and Governance documentation

### DIFF
--- a/site/content/docs/contribute/core-team.md
+++ b/site/content/docs/contribute/core-team.md
@@ -32,3 +32,12 @@ As well as being a welcoming, community oriented Open Source project it is (we b
 Being part of a significant Open Source project is a great way to learn, grow, and raise your profile in the industry.
 
 It can also really help your career - everyone who has been a member of the ZAP Core Team for any length of time has had job offers due to their association with ZAP. Some of us have even accepted them :smiley:
+
+### Duties
+
+Include, but are not limited to:
+- Contributing to ZAP.
+- Promoting ZAP within the industry.
+- Supporting users, developers, and the Core Team.
+- Performing tasks related to releases as needed.
+- Other tasks as required/agreed.

--- a/site/content/docs/contribute/roles-and-governance.md
+++ b/site/content/docs/contribute/roles-and-governance.md
@@ -1,0 +1,17 @@
+---
+title: "Roles and Governance"
+type: page
+cascade:
+  EditableContent: true
+  addBreadcrumbs: true
+---
+
+ZAP's governance model is simple.
+
+There are two roles: [general contributors](/docs/desktop/credits/#zap-extended-team), and the [Core Team](/docs/team/).
+
+Decisions within the project are made based on majority rules. That is to say, if someone puts forth a new idea or decision to be made, it is made based on the majority of the team agreeing on the direction/outcome. 
+
+Anyone can work on anything they like. It is a majority Core Team decision as to whether any significant new functionality is adopted (and therefore supported) by the Core Team.
+
+All pull requests must be approved by two members of the Core Team, not including the submitter.


### PR DESCRIPTION
To be used for OpenSSF Best Practices Silver.
https://bestpractices.coreinfrastructure.org/en/projects/24?criteria_level=1

"_The project MUST clearly define and document its project governance model (the way it makes decisions, including key roles)._"

"_The project MUST clearly define and publicly document the key roles in the project and their responsibilities, including any tasks those roles must perform. It MUST be clear who has which role(s), though this might not be documented in the same way._"

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>