### PR TITLE
Update roadmap

### DIFF
--- a/site/content/docs/roadmap/_index.md
+++ b/site/content/docs/roadmap/_index.md
@@ -2,4 +2,6 @@
 title: "Roadmap"
 type: roadmap
 ---
+No target dates are given as much of the work on ZAP is done by volunteers. We also aim to react very quickly to urgent issues which inevitably delays other planned work.
+
 These are the major items on ZAP's roadmap for the next few years:

--- a/site/data/roadmap.yaml
+++ b/site/data/roadmap.yaml
@@ -1,10 +1,10 @@
-- item: Continue working on issues
-  status: In progress
-  url: https://github.com/zaproxy/zaproxy/issues
-  year: 2022
 - item: Networking overhaul
   status: Finished
   url: https://www.zaproxy.org/blog/2022-02-10-new-zap-networking-layer/
+  year: 2022
+- item: Continue working on issues
+  status: In progress
+  url: https://github.com/zaproxy/zaproxy/issues
   year: 2022
 - item: Continue improving scan rules
   status: In progress
@@ -30,13 +30,17 @@
   status: In progress
   year: 2022
 - item: Release 2.12
-  status: Not started
+  status: In progress
   year: 2022
 - item: "Networking: Initial HTTP/2 support"
-  status: Not started
+  status: In progress
   year: 2022
 - item: Move core functionality to add-ons
   status: In progress
+  year: 2022
+- item: "OpenSSF Best Practices: Silver"
+  status: In progress
+  url: https://bestpractices.coreinfrastructure.org/en/projects/24?criteria_level=1
   year: 2022
 
 - item: Continue working on issues


### PR DESCRIPTION
Update status of HTTP/2 support and release of 2.12.
Add entry for OpenSSF Best Practices.
Reorder the entries to have Finished before In progress.
Add note about no target dates.