### PR TITLE
 Note that Firefox and Chrome do not proxy localhost by default

### DIFF
--- a/site/content/faq/how-do-you-configure-zap-to-test-an-application-on-localhost.md
+++ b/site/content/faq/how-do-you-configure-zap-to-test-an-application-on-localhost.md
@@ -16,4 +16,8 @@ Proxies](/docs/desktop/ui/dialogs/options/localproxy/) screen, remember to chang
 browser's proxy settings as well: [Configuring Proxies](/docs/desktop/start/proxies/).
 
 You also need to check that you have not configured your browser to ignore
-your configured proxy (ZAP) for localhost.
+the configured proxy (ZAP) for localhost. Note that Firefox (>= version 67)
+and Chrome (>= version 72) by default do not proxy loopback addresses' traffic
+(which includes localhost).
+[Configuring Proxies](/docs/desktop/start/proxies/) explains how to reconfigure
+them to proxy loopback addresses' traffic.


### PR DESCRIPTION
Re-implement https://github.com/zaproxy/zaproxy-website/pull/1120

Done via github.dev, I do agree with https://developercertificate.org/