### PR TITLE
Alert tag tweaks

### DIFF
--- a/site/content/docs/alerts/_index.md
+++ b/site/content/docs/alerts/_index.md
@@ -10,3 +10,6 @@ Note that these are examples of the alerts raised - many rules include different
 Only the `release` rules are included in ZAP by default, the beta and alpha rules can be installed via the [ZAP Marketplace](/addons/).
 
 You can also use HTTP passive and active scripts, examples of which are available in the ZAP [community scripts](https://github.com/zaproxy/community-scripts) repo, as well as Websocket [passive](/docs/desktop/addons/websockets/pscanrules/) scripts.
+
+Many alerts support [tags](/alerttags/) which allow you to see which alerts are related to, for example, specific
+[OWASP Top Ten](https://owasp.org/Top10/) categories or [OWASP Web Service Testing Guide](https://owasp.org/www-project-web-security-testing-guide/) chapters.

--- a/site/layouts/alerttags/list.html
+++ b/site/layouts/alerttags/list.html
@@ -34,13 +34,16 @@
       <table data-sort-filter>
          <thead>
             <tr>
-               <th>Search</th>
+               <th>Tag</th>
+               <th>Link</th>
             </tr>
          </thead>
          <tbody>
             {{ range .Pages }}
+               {{ $alerttag := index $.Site.Data.alerttags .Title }}
                <tr>
                   <td><a href="{{ .Permalink }}">{{ .Title }}</a></td>
+                  <td><a href="{{ $alerttag.link }}">{{ $alerttag.link }}</a></td>
                </tr>
             {{ end }}
          </tbody>


### PR DESCRIPTION
Added note about the tags (and a link to the list):
![Screenshot 2022-10-28 at 13-12-21 OWASP ZAP – ZAP Alert Details](https://user-images.githubusercontent.com/1081115/198574312-4d6f6b0e-e925-4c06-8da9-e7c7bb0383ae.png)

And added the links to the list:
![Screenshot 2022-10-28 at 13-12-29 OWASP ZAP – Alerttags](https://user-images.githubusercontent.com/1081115/198574367-6c32414a-cc3b-4f57-9c95-d8c73676cae3.png)


Signed-off-by: Simon Bennetts <psiinon@gmail.com>