### PR TITLE
Generate help of add-on

### DIFF
--- a/site/content/docs/desktop/addons/database/_index.md
+++ b/site/content/docs/desktop/addons/database/_index.md
@@ -1,0 +1,18 @@
+---
+# This page was generated from the add-on.
+title: Database Add-on
+type: userguide
+weight: 1
+cascade:
+  addon:
+    id: database
+    version: 0.1.0
+---
+
+# Database Add-on
+
+An add-on that provides database engines and other related infrastructure.
+
+It provides the following database engines:
+
+* SQLite, through [SQLite JDBC Driver](https://github.com/xerial/sqlite-jdbc).


### PR DESCRIPTION
Generate the help of Database version 0.1.0.

---
Missed while releasing, enabled in zaproxy/zap-admin#854