### PR TITLE
Added team pix and social links

### DIFF
--- a/site/layouts/team/list.html
+++ b/site/layouts/team/list.html
@@ -1,34 +1,70 @@
-{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }}
-{{ define "main" }}
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ .Title }}{{ end }} {{
+define "main" }}
 <section class="bolt-header">
-   <div class="wrapper py-20">
-      <h1 class="text--white">{{ .Title }}</h1>
-   </div>
+	<div class="wrapper py-20">
+		<h1 class="text--white">{{ .Title }}</h1>
+	</div>
 </section>
 <div class="wrapper py-20">
-    <header class="breadcrumbs">
-        <a href="/community/">Community</a>
-    </header>
-   {{ .Content }}
-   <div class="flex latest-versions">
-      <table>
-         <thead>
-            <tr>
-               <th>Handle</th>
-               <th>Name</th>
-               <th>Role(s)</th>
-            </tr>
-         </thead>
-         <tbody>
-            {{ range (.Pages.ByParam "alertindex") }}
-               <tr>
-                  <td><a href="{{ .Permalink }}">{{ .Params.handle }}</a></td>
-                  <td><a href="{{ .Permalink }}">{{ .Params.name }}</a></td>
-                  <td>{{ .Params.roles }}</td>
-               </tr>
-            {{ end }}
-         </tbody>
-      </table>
-   </div>
+	<header class="breadcrumbs">
+		<a href="/community/">Community</a>
+	</header>
+	{{ .Content }}
+	<div class="flex latest-versions">
+		<table>
+			<thead>
+				<tr>
+					<th></th>
+					<th>Handle</th>
+					<th>Name</th>
+					<th colspan="3">Contact</th>
+					<th>Role(s)</th>
+				</tr>
+			</thead>
+			<tbody>
+				{{ range (.Pages.ByParam "alertindex") }} {{ $authorRec := index
+				$.Site.Data.authors .Params.author }}
+				<tr>
+					<td width="42">{{ if $authorRec.picture }} <img
+						src="{{ $authorRec.picture }}"
+						style="border-radius: 50%; width: 40px; display: block"
+						width="40px" /> {{ end }}
+					</td>
+					<td><a href="{{ .Permalink }}">{{ .Params.handle }}</a></td>
+					<td><a href="{{ .Permalink }}">{{ .Params.name }}</a></td>
+					<td width="26">{{ if $authorRec.twitter }} <a
+						href="https://twitter.com/{{ $authorRec.twitter }}"
+						style="border-bottom: none;"> <!-- c/o https://iconmonstr.com/twitter-1-svg/ -->
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+								viewBox="0 0 24 24">
+                            <path
+									d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z" />
+                            </svg>
+					</a> {{ end }}
+					</td>
+					<td width="26">{{ if .Params.linkedin }} <a
+						href="https://www.linkedin.com/in/{{ .Params.linkedin }}/"
+						style="border-bottom: none;"> <!--  c/o https://iconmonstr.com/linkedin-3-svg/ -->
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+								viewBox="0 0 24 24">
+                        <path
+									d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
+                      </svg>
+					</a> {{ end }}
+					</td>
+					<td width="26">{{ if .Params.mastodon }} <a
+						href="{{ .Params.mastodon }}" style="border-bottom: none;"> <!--  c/o https://www.svgrepo.com/svg/330895/mastodon -->
+							<svg width="24px" height="24px" viewBox="0 0 24 24" role="img"
+								xmlns="http://www.w3.org/2000/svg">
+								<path
+									d="M23.193 7.88c0-5.207-3.411-6.733-3.411-6.733C18.062.357 15.108.025 12.041 0h-.076c-3.069.025-6.02.357-7.74 1.147 0 0-3.412 1.526-3.412 6.732 0 1.193-.023 2.619.015 4.13.124 5.092.934 10.11 5.641 11.355 2.17.574 4.034.695 5.536.612 2.722-.15 4.25-.972 4.25-.972l-.09-1.975s-1.945.613-4.13.54c-2.165-.075-4.449-.234-4.799-2.892a5.5 5.5 0 0 1-.048-.745s2.125.52 4.818.643c1.646.075 3.19-.097 4.758-.283 3.007-.359 5.625-2.212 5.954-3.905.517-2.665.475-6.508.475-6.508zm-4.024 6.709h-2.497v-6.12c0-1.29-.543-1.944-1.628-1.944-1.2 0-1.802.776-1.802 2.313v3.349h-2.484v-3.35c0-1.537-.602-2.313-1.802-2.313-1.085 0-1.628.655-1.628 1.945v6.119H4.831V8.285c0-1.29.328-2.314.987-3.07.68-.759 1.57-1.147 2.674-1.147 1.278 0 2.246.491 2.886 1.474L12 6.585l.622-1.043c.64-.983 1.608-1.474 2.886-1.474 1.104 0 1.994.388 2.674 1.146.658.757.986 1.781.986 3.07v6.305z" /></svg>
+					</a> {{ end }}
+					</td>
+					<td>{{ .Params.roles }}</td>
+				</tr>
+				{{ end }}
+			</tbody>
+		</table>
+	</div>
 </div>
 {{ end }}


### PR DESCRIPTION
Planned to do this the first time around but didnt manage it 😉 

![Screenshot 2022-11-14 at 11-43-50 OWASP ZAP – ZAP Team](https://user-images.githubusercontent.com/1081115/201652112-655c2041-9173-4326-a15e-b057a6dd8309.png)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>