### PR TITLE
Add technology tags

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -16,6 +16,7 @@ taxonomies:
   successtag: "successtags"
   alerttag: "alerttags"
   author: "authors"
+  techtag: "techtags"
 
 params:
   description: 

--- a/site/content/docs/alerts/20017.md
+++ b/site/content/docs/alerts/20017.md
@@ -41,6 +41,8 @@ references:
    - http://cwe.mitre.org/data/definitions/89.html
 cwe: 20
 wasc: 20
+techtags: 
+  - Language.PHP
 alerttags: 
   - OWASP_2017_A09
   - OWASP_2021_A06

--- a/site/content/docs/alerts/20018.md
+++ b/site/content/docs/alerts/20018.md
@@ -41,6 +41,8 @@ references:
    - http://cwe.mitre.org/data/definitions/89.html
 cwe: 20
 wasc: 20
+techtags: 
+  - Language.PHP
 alerttags: 
   - OWASP_2017_A09
   - OWASP_2021_A06

--- a/site/content/docs/alerts/30001.md
+++ b/site/content/docs/alerts/30001.md
@@ -12,6 +12,8 @@ references:
    - https://owasp.org/www-community/attacks/Buffer_overflow_attack
 cwe: 120
 wasc: 7
+techtags: 
+  - Language.C
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/30002.md
+++ b/site/content/docs/alerts/30002.md
@@ -12,6 +12,8 @@ references:
    - https://owasp.org/www-community/attacks/Format_string_attack
 cwe: 134
 wasc: 6
+techtags: 
+  - Language.C
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/30003.md
+++ b/site/content/docs/alerts/30003.md
@@ -14,6 +14,8 @@ references:
    - http://projects.webappsec.org/w/page/13246946/Integer%20Overflows
 cwe: 190
 wasc: 3
+techtags: 
+  - Language.C
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40009.md
+++ b/site/content/docs/alerts/40009.md
@@ -13,6 +13,10 @@ references:
    - http://www.carleton.ca/~dmcfet/html/ssi.html
 cwe: 97
 wasc: 31
+techtags: 
+  - OS.Linux
+  - OS.MacOS
+  - OS.Windows
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40018.md
+++ b/site/content/docs/alerts/40018.md
@@ -23,6 +23,20 @@ references:
    - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
 cwe: 89
 wasc: 19
+techtags: 
+  - Db.CouchDB
+  - Db.Firebird
+  - Db.HypersonicSQL
+  - Db.IBM_DB2
+  - Db.Microsoft_Access
+  - Db.Microsoft_SQL_Server
+  - Db.MongoDB
+  - Db.MySQL
+  - Db.Oracle
+  - Db.PostgreSQL
+  - Db.SAP_MaxDB
+  - Db.SQLite
+  - Db.Sybase
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40019.md
+++ b/site/content/docs/alerts/40019.md
@@ -23,6 +23,8 @@ references:
    - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
 cwe: 89
 wasc: 19
+techtags: 
+  - Db.MySQL
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40020.md
+++ b/site/content/docs/alerts/40020.md
@@ -23,6 +23,8 @@ references:
    - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
 cwe: 89
 wasc: 19
+techtags: 
+  - Db.HypersonicSQL
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40021.md
+++ b/site/content/docs/alerts/40021.md
@@ -23,6 +23,8 @@ references:
    - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
 cwe: 89
 wasc: 19
+techtags: 
+  - Db.Oracle
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40022.md
+++ b/site/content/docs/alerts/40022.md
@@ -23,6 +23,8 @@ references:
    - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
 cwe: 89
 wasc: 19
+techtags: 
+  - Db.PostgreSQL
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40024.md
+++ b/site/content/docs/alerts/40024.md
@@ -23,6 +23,8 @@ references:
    - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
 cwe: 89
 wasc: 19
+techtags: 
+  - Db.SQLite
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40027.md
+++ b/site/content/docs/alerts/40027.md
@@ -23,6 +23,8 @@ references:
    - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
 cwe: 89
 wasc: 19
+techtags: 
+  - Db.Microsoft_SQL_Server
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40028.md
+++ b/site/content/docs/alerts/40028.md
@@ -14,6 +14,11 @@ references:
    - https://elmah.github.io/
 cwe: 94
 wasc: 14
+techtags: 
+  - Db.Microsoft_SQL_Server
+  - Language.ASP
+  - OS.Windows
+  - WS.IIS
 alerttags: 
   - OWASP_2017_A06
   - OWASP_2021_A05

--- a/site/content/docs/alerts/40029.md
+++ b/site/content/docs/alerts/40029.md
@@ -14,6 +14,11 @@ references:
    - https://www.dotnetperls.com/trace
 cwe: 215
 wasc: 13
+techtags: 
+  - Db.Microsoft_SQL_Server
+  - Language.ASP
+  - OS.Windows
+  - WS.IIS
 alerttags: 
   - OWASP_2017_A06
   - OWASP_2021_A05

--- a/site/content/docs/alerts/40032.md
+++ b/site/content/docs/alerts/40032.md
@@ -12,6 +12,8 @@ references:
    - http://www.htaccess-guide.com/
 cwe: 94
 wasc: 14
+techtags: 
+  - WS.Apache
 alerttags: 
   - OWASP_2017_A06
   - OWASP_2021_A05

--- a/site/content/docs/alerts/40033.md
+++ b/site/content/docs/alerts/40033.md
@@ -14,6 +14,8 @@ references:
    - https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.html
 cwe: 943
 wasc: 19
+techtags: 
+  - Db.MongoDB
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/40042.md
+++ b/site/content/docs/alerts/40042.md
@@ -12,6 +12,9 @@ references:
    - https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#overview
 cwe: 215
 wasc: 13
+techtags: 
+  - Language.Java
+  - Language.Java.Spring
 alerttags: 
   - OWASP_2017_A05
   - OWASP_2021_A01

--- a/site/content/docs/alerts/40043-1.md
+++ b/site/content/docs/alerts/40043-1.md
@@ -14,6 +14,8 @@ references:
    - https://nvd.nist.gov/vuln/detail/CVE-2021-44228
 cwe: 117
 wasc: 20
+techtags: 
+  - Language.Java
 alerttags: 
   - OUT_OF_BAND
   - OWASP_2017_A09

--- a/site/content/docs/alerts/40043-2.md
+++ b/site/content/docs/alerts/40043-2.md
@@ -14,6 +14,8 @@ references:
    - https://nvd.nist.gov/vuln/detail/CVE-2021-45046
 cwe: 117
 wasc: 20
+techtags: 
+  - Language.Java
 alerttags: 
   - OUT_OF_BAND
   - OWASP_2017_A09

--- a/site/content/docs/alerts/40045.md
+++ b/site/content/docs/alerts/40045.md
@@ -14,6 +14,9 @@ references:
    - https://tanzu.vmware.com/security/cve-2022-22965
 cwe: 78
 wasc: 20
+techtags: 
+  - Language.Java
+  - Language.Java.Spring
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2017_A09

--- a/site/content/docs/alerts/40047.md
+++ b/site/content/docs/alerts/40047.md
@@ -13,6 +13,8 @@ references:
    - https://securitylab.github.com/advisories/GHSL-2022-018_Apache_Commons_Text/
 cwe: 117
 wasc: 20
+techtags: 
+  - Language.Java
 alerttags: 
   - CVE-2022-42889
   - OUT_OF_BAND

--- a/site/content/docs/alerts/90019.md
+++ b/site/content/docs/alerts/90019.md
@@ -15,6 +15,9 @@ references:
    - https://owasp.org/www-community/attacks/Direct_Dynamic_Code_Evaluation_Eval%20Injection
 cwe: 94
 wasc: 20
+techtags: 
+  - Language.ASP
+  - Language.PHP
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/90020.md
+++ b/site/content/docs/alerts/90020.md
@@ -42,6 +42,10 @@ references:
    - https://owasp.org/www-community/attacks/Command_Injection
 cwe: 78
 wasc: 31
+techtags: 
+  - OS.Linux
+  - OS.MacOS
+  - OS.Windows
 alerttags: 
   - OWASP_2017_A01
   - OWASP_2021_A03

--- a/site/content/docs/alerts/_index.md
+++ b/site/content/docs/alerts/_index.md
@@ -13,3 +13,6 @@ You can also use HTTP passive and active scripts, examples of which are availabl
 
 Many alerts support [tags](/alerttags/) which allow you to see which alerts are related to, for example, specific
 [OWASP Top Ten](https://owasp.org/Top10/) categories or [OWASP Web Service Testing Guide](https://owasp.org/www-project-web-security-testing-guide/) chapters.
+
+Some alerts are only relevant for specific [technologies](/techtags/) - if you know your target app does _not_ use some of these technologies then you can configure ZAP
+to skip those tests.

--- a/site/layouts/alert/single.html
+++ b/site/layouts/alert/single.html
@@ -65,6 +65,20 @@
             </tr>
             <tr> 
               <td>
+                <strong>Technologies Targeted</strong>
+              </td>
+              <td>
+              {{ if isset .Params "techtags" }}
+                {{ range $tag := .Params.techtags }}
+                	<a href="/techtags/{{ lower $tag }}">{{ replace (replace $tag "_" " ") "." " / " }}</a><br>
+                {{ end }}
+              {{ else }}
+                All
+              {{ end }}
+	          </td>
+            </tr>
+            <tr> 
+              <td>
                 <strong>Tags</strong>
               </td>
               <td>

--- a/site/layouts/techtags/list.html
+++ b/site/layouts/techtags/list.html
@@ -1,0 +1,45 @@
+{{ define "title" }}{{ .Site.Title }} &ndash; {{ replace (replace .Title "_" " ") "." " / " }}{{ end }}
+{{ define "main" }}
+<section class="bolt-header">
+  <div class="wrapper py-20">
+    {{ if eq .Title "Techtags" }}
+      <h1 class="text--white">Technologies</h1>
+    {{ else }}
+      <h1 class="text--white">Technology:  {{ replace (replace .Title "_" " ") "." " / " }}</h1>
+    {{ end }}
+  </div>
+</section>
+  <div class="wrapper py-70">
+    <header class="breadcrumbs">
+        <a href="/techtags/">Technologies</a> &gt;
+        {{ if ne .Title "Techtags" }}
+        <a href="/techtags/{{ lower .Title }}">{{ replace (replace .Title "_" " ") "." " / " }}</a>
+        {{ end }}
+    </header>
+   {{ .Content }}
+
+    {{ if eq .Title "Techtags" }}
+      All of the defined technologies which are relevant to specific <a href="/docs/alerts/">alerts</a>:
+    {{ else }}
+      <h4>{{ replace (replace .Title "_" " ") "." " / " }}</h4>
+      All of the alerts which explicitly target this technology:
+    {{ end }}
+
+   <div class="flex latest-versions">
+      <table data-sort-filter>
+         <thead>
+            <tr>
+               <th>Technology</th>
+            </tr>
+         </thead>
+         <tbody>
+            {{ range .Pages }}
+               <tr>
+                  <td><a href="{{ .Permalink }}">{{ replace (replace .Title "_" " ") "." " / " }}</a></td>
+               </tr>
+            {{ end }}
+         </tbody>
+      </table>
+   </div>
+  </div>
+{{ end }} 


### PR DESCRIPTION
Add technology links to the alerts and pages which map back.

![Screenshot 2022-11-24 at 15-00-27 OWASP ZAP – ELMAH Information Leak](https://user-images.githubusercontent.com/1081115/203814909-3c71acee-1ccb-42eb-a642-e98700dab42f.png)

![Screenshot 2022-11-24 at 14-59-54 OWASP ZAP – Techtags](https://user-images.githubusercontent.com/1081115/203814934-a5b25fd2-ed2f-4a62-8910-31cf7742ddde.png)

![Screenshot 2022-11-24 at 15-00-17 OWASP ZAP – Language _ ASP](https://user-images.githubusercontent.com/1081115/203814951-77cf4d4f-913a-44d9-bcf6-8df0aae2ad95.png)

The techtags are generated by the alert pages script - I'll submit a PR to update that next..

Signed-off-by: Simon Bennetts <psiinon@gmail.com>