### PR TITLE
add-ons help tweaks (https-info, tls-debug, neonmarker)

### DIFF
--- a/site/content/docs/desktop/addons/https-info/_index.md
+++ b/site/content/docs/desktop/addons/https-info/_index.md
@@ -9,28 +9,4 @@ cascade:
     version: 13.0.0
 ---
 
-# HTTPS Info
-
-The HTTPS Info add-on is accessed via the context menu within the Sites Tree or History table.
-It displays tabs in a status panel, in which various summary information is displayed
-regarding the target server's HTTPS certificate, and the offered SSL/TLS cipher suites.
-
-This add-on leverages another OWASP project:
-[Deep Violet](https://github.com/spoofzu/DeepViolet/)
-to perform it's certificate and cipher suite information gathering.
-
-## General
-
-The top portion of a tab is devoted to general details of the SSL/TLS certificate presented by the server. Such as:
-
-* Subject DN
-* Signing Algorithm
-* Certificate Fingerprint
-* Issuer DN
-* Validity Dates
-* Self-signed Status
-* etc.
-
-## Cipher Suites
-
-The bottom portion of a tab is devoted to enumeration/listing of the specific Cipher Suites the target server offers, grouped by handshake protocol (SSLv2, SSLv3, TLSv1, TLSv1.1, etc.).
+This add-on has been retired and is no longer available.

--- a/site/content/docs/desktop/addons/neonmarker/_index.md
+++ b/site/content/docs/desktop/addons/neonmarker/_index.md
@@ -11,6 +11,15 @@ cascade:
 
 # Neonmarker
 
-Neonmarker addon, which colours History table entries based on tags. The add-on also facilitates colouring arbitrary messages in the History table via a right-click context menu. Tags are added to the selected messages to deliver the necessary colouring. Neonmarker's custom tags take the form `neon_UUID`, for example: `neon_e8b1d1e6-9dd4-4996-bc02-de2213986352`. Another context menu item provides functionality to remove Neonmarker's custom tags. The following code example shows how to add a Neonmarker colorMapping via JavaScript within ZAP using a Stand Alone script. `extNeon = org.parosproxy.paros.control.Control.getSingleton().getExtensionLoader().getExtension(org.zaproxy.zap.extension.neonmarker.ExtensionNeonmarker.NAME);
+Neonmarker addon, which colours History table entries based on tags.
+
+The add-on also facilitates colouring arbitrary messages in the History table via a right-click context menu. Tags are added to the selected messages to deliver the necessary colouring. Neonmarker's custom tags take the form `neon_UUID`, for example: `neon_e8b1d1e6-9dd4-4996-bc02-de2213986352`. Another context menu item provides functionality to remove Neonmarker's custom tags.
+
+The following code example shows how to add a Neonmarker colorMapping via JavaScript within ZAP using a Stand Alone script.
+
+```
+extNeon = org.parosproxy.paros.control.Control.getSingleton().getExtensionLoader().getExtension(org.zaproxy.zap.extension.neonmarker.ExtensionNeonmarker.NAME);
+
 // History items tagged “Comment” will be red
-extNeon.addColorMapping("Comment", 0x990000);`
+extNeon.addColorMapping("Comment", 0x990000);
+```

--- a/site/content/docs/desktop/addons/tls-debug/_index.md
+++ b/site/content/docs/desktop/addons/tls-debug/_index.md
@@ -9,17 +9,4 @@ cascade:
     version: 5.0.0
 ---
 
-# TLS Debug
-
-This add-on displays the TLS trace on a dedicated tab.
-
-Type the URL to connect to in the input field and press Check.
-
-Right click the output console to clear the trace.
-
-Note that ZAP configurations are not yet considered. These are features for the next version:
-
-* Select the level of details of the trace ("all", "ssl")
-* Use a client certificate
-* Use an outgoing proxy
-
+This add-on has been retired and is no longer available.


### PR DESCRIPTION
- https-info > Add retirement note.
- tls-info > Add retirement note.
- neonmarker > Update formatting to not be all compressed together. (In conjunction with https://github.com/kingthorin/neonmarker/pull/23)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>