### PR TITLE
Display supporters in a neat grid

### DIFF
--- a/site/layouts/page/download.html
+++ b/site/layouts/page/download.html
@@ -241,22 +241,15 @@
     </div>
   </section>
 
-  <div class="wrapper">
-    <h5>A big thank you to our Platinum Sponsor(s):</h5>
-
-{{ range $supporter := $.Site.Data.supporters.platinum }}
-  <a href="{{ $supporter.link }}"><img src="{{ $supporter.logo }}" /></a>&nbsp;&nbsp;
-{{ end }}
-
-    <h5>And Gold Sponsor(s):</h5>
-
-{{ range $supporter := $.Site.Data.supporters.gold }}
-  <a href="{{ $supporter.link }}"><img src="{{ $supporter.logo }}" /></a>&nbsp;&nbsp;
-{{ end }}
-
-<h5>For details of other ZAP sponsors see the <a href="/supporters/">Supporters</a> page.</h5>
-
-  </div>
+  <section class="py-20">
+    <div class="wrapper">
+      <h5>A big thank you to our Platinum Sponsor(s):</h5>
+      {{ partial "supporters.html" (dict "supporters" $.Site.Data.supporters.platinum) }}
+      <h5>And Gold Sponsor(s):</h5>
+      {{ partial "supporters.html" (dict "supporters" $.Site.Data.supporters.gold) }}
+      <h5>For details of other ZAP sponsors see the <a href="/supporters/">Supporters</a> page.</h5>
+    </div>
+  </section>
 
 
 {{ end }}

--- a/site/layouts/page/supporters.html
+++ b/site/layouts/page/supporters.html
@@ -15,28 +15,15 @@
 {{- .Content -}}
 
 <h2>Platinum</h2>
-
-{{ range $supporter := $.Site.Data.supporters.platinum }}
-  <a href="{{ $supporter.link }}"><img src="{{ $supporter.logo }}" /></a>&nbsp;&nbsp;
-{{ end }}
+{{ partial "supporters.html" (dict "supporters" $.Site.Data.supporters.platinum) }}
 <br/><br/>
 
 <h2>Gold</h2>
-
-{{ range $supporter := $.Site.Data.supporters.gold }}
-  <a href="{{ $supporter.link }}"><img src="{{ $supporter.logo }}" /></a>&nbsp;&nbsp;
-{{ end }}
+{{ partial "supporters.html" (dict "supporters" $.Site.Data.supporters.gold) }}
 <br/><br/>
 
 <h2>Silver</h2>
-
-{{ range $supporter := $.Site.Data.supporters.silver }}
-  {{ if $supporter.logo }}
-    <a href="{{ $supporter.link }}"><img src="{{ $supporter.logo }}" /></a>&nbsp;&nbsp;
-  {{ else }}
-    <h3><a href="{{ $supporter.link }}">{{ $supporter.name }}</a></h3>
-  {{ end }}
-{{ end }}
+{{ partial "supporters.html" (dict "supporters" $.Site.Data.supporters.silver) }}
 <br/><br/>
 
 <h2>Bronze</h2>

--- a/site/layouts/partials/homepage/sponsors.html
+++ b/site/layouts/partials/homepage/sponsors.html
@@ -1,12 +1,7 @@
 <section class="py-20">
   <div class="wrapper">
     <h5>A big thank you to our Platinum Sponsor(s):</h5>
-
-{{ range $supporter := $.Site.Data.supporters.platinum }}
-  <a href="{{ $supporter.link }}"><img src="{{ $supporter.logo }}" /></a>&nbsp;&nbsp;
-{{ end }}
-
-<h5>For details of other ZAP sponsors see the <a href="/supporters/">Supporters</a> page.</h5>
-
+    {{ partial "supporters.html" (dict "supporters" $.Site.Data.supporters.platinum) }}
+    <h5>For details of other ZAP sponsors see the <a href="/supporters/">Supporters</a> page.</h5>
   </div>
 </section>

--- a/site/layouts/partials/supporters.html
+++ b/site/layouts/partials/supporters.html
@@ -1,0 +1,13 @@
+<div class="supporters-grid mb-30">
+    {{ range $supporter := .supporters }}
+    <a href="{{ $supporter.link }}" class="pt-30 px-30 card flex jc-c ai-c fd-c br-def">
+        {{ if $supporter.logo }}
+        <div class="mb-30">
+            <img src="{{ $supporter.logo }}" style="width:100%;" />
+        </div>
+        {{ else }}
+        <h3> {{ $supporter.name }} </h3>
+        {{ end }}
+    </a>
+    {{ end }}
+</div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -46,4 +46,5 @@
 @import 'pages/homepage.scss';
 @import 'pages/download.scss';
 @import 'pages/blog.scss';
+@import 'pages/supporters.scss';
 @import 'terminal';

--- a/src/css/pages/supporters.scss
+++ b/src/css/pages/supporters.scss
@@ -1,0 +1,13 @@
+.supporters-grid {
+    display: grid;
+    column-gap: 30px;
+    row-gap: 30px;
+    grid-template-columns: 1fr 1fr 1fr;
+}
+
+@media screen and (max-width: 850px) {
+    .supporters-grid {
+        grid-template-columns: 1fr;
+        row-gap: 0;
+    }
+}


### PR DESCRIPTION
Screenshots:

<details><summary>Homepage</summary>

![image](https://user-images.githubusercontent.com/16446369/225124301-48d0905a-69f3-4fdb-a967-36910edcb53b.png)

</details>
<details><summary>Downloads Page</summary>

![image](https://user-images.githubusercontent.com/16446369/225124454-740406c2-ed2f-40f5-a82e-c77d15338aa5.png)

</details>
<details><summary>Supporters Page</summary>

![image](https://user-images.githubusercontent.com/16446369/225124557-e4490f4e-b182-4332-a66e-a45793709216.png)

</details>