### PR TITLE
Sponsorship and roadmap updates

### DIFF
--- a/site/content/docs/roadmap/_index.md
+++ b/site/content/docs/roadmap/_index.md
@@ -4,4 +4,6 @@ type: roadmap
 ---
 No target dates are given as much of the work on ZAP is done by volunteers. We also aim to react very quickly to urgent issues which inevitably delays other planned work.
 
+For details of how to sponsor ZAP developments see the [Sponsor](/sponsor) page.
+
 These are the major items on ZAP's roadmap for the next few years:

--- a/site/content/sponsor.md
+++ b/site/content/sponsor.md
@@ -27,6 +27,9 @@ You can also sponsor the following members of the Core team directly - these con
 * [kingthorin](https://github.com/sponsors/kingthorin)
 * [ricekot](https://github.com/sponsors/ricekot)
 
+If you have any questions about sponsorship then please [get in touch](mailto:zaproxy-admin@googlegroups.com) - 
+we want to make it straightforward and as mutually beneficial as possible.
+
 ## Sponsorship Levels and Benefits
 
 ### Platinum
@@ -37,10 +40,12 @@ You can also sponsor the following members of the Core team directly - these con
 
 ##### Benefits
 
-* Priority Support
+* Significant say in the work implemented by the sponsored team members (see [Caveats](#caveats)).
+* Priority Support.
 * Logo and Link on the [main page](/).
 * Logo and Link on the [Download](/download/) page.
 * Logo and Link on the [Supporters](/supporters/) page.
+* Name and link on any sponsored [Roadmap](/docs/roadmap) items.
 * Priority placement on [Third Party Products and Services](/third-party-services/) page.
 * Priority placement on [Success Stories](/success/) page.
 
@@ -48,12 +53,14 @@ You can also sponsor the following members of the Core team directly - these con
 
 ##### Criteria
 
-* A significant investment in time or money, equivalent to $8,000 or more.
+* A significant investment in time or money, equivalent to $10,000 or more.
 
 ##### Benefits
 
+* Option to sponsor specific major developments (see [Caveats](#caveats)).
 * Logo and Link on the [Download](/download/) page.
 * Logo and Link on the [Supporters](/supporters/) page.
+* Name and link on any sponsored [Roadmap](/docs/roadmap) items.
 * Priority placement on [Third Party Products and Services](/third-party-services/) page.
 * Priority placement on [Success Stories](/success/) page.
 
@@ -61,7 +68,8 @@ You can also sponsor the following members of the Core team directly - these con
 
 ##### Criteria
 
-* An investment in time or money, equivalent to $1,000 or more.
+* Option to sponsor specific less involved developments (see [Caveats](#caveats)).
+* An investment in time or money, equivalent to $5,000 or more.
 
 ##### Benefits
 
@@ -73,19 +81,33 @@ You can also sponsor the following members of the Core team directly - these con
 
 ##### Criteria
 
-* An investment in time or money, equivalent to more than $200 and less than $1,000.
+* An investment in time or money, equivalent to more than $1,000.
 
 ##### Benefits
 
-* Name and Link on the [Supporters](/supporters/) page.
+* Logo (for new Bronze supporters, name for previous ones) and Link on the [Supporters](/supporters/) page.
 * Priority placement on [Third Party Products and Services](/third-party-services/) page.
 * Priority placement on [Success Stories](/success/) page.
 
-Note that all benefits are under continual review and are subject to change without notice.
+### Community
+
+##### Criteria
+
+* Any contributions less than $1,000.
+
+##### Benefits
+
+* Name on the [Supporters](/supporters/) page.
+
+### Caveats
+
+Any work undertaken as part of sponsorship will need to be compatible with the [Roadmap](/docs/roadmap/). 
+
+All benefits are under continual review and are subject to change without notice.
 
 ### Historic Donations
 
-Supporters will move down one level each full calendar year after the last donation.
+Supporters will move down one level each full calendar year after the last donation. Supporters will not be removed from the Community section.
 
 Note that companies whose actions are considered to be damaging to the ZAP project may be demoted or even be removed 
 from the [Supporters](/supporters/) page, at the discretion of the ZAP Core Team.

--- a/site/data/roadmap.yaml
+++ b/site/data/roadmap.yaml
@@ -1,44 +1,28 @@
-- item: Networking overhaul
-  status: 🎉 Finished
-  url: https://www.zaproxy.org/blog/2022-02-10-new-zap-networking-layer/
-  year: 2022
-- item: Migrate manual request editor out of core
-  status: 🎉 Finished
-  year: 2022
-- item: Migrate Spider out of core
-  status: 🎉 Finished
-  url: https://www.zaproxy.org/blog/2022-08-30-spider-move/
-  year: 2022
-- item: Update minimum Java version to 11
-  status: 🎉 Finished
-  year: 2022
-- item: Add permanent DB support
-  status: 🎉 Finished
-  url: https://github.com/zaproxy/zap-extensions/pull/3699
-  year: 2022
-- item: Release 2.12
-  status: 🎉 Finished
-  url: /blog/2022-10-27-zap-2-12-0-the-ten-thousand-star-release/
-  year: 2022
 
+- item: Authentication handling improvements
+  status: ⚡ In progress
+  url: /blog/2023-01-19-authentication-help/
+  sponsor: Jit
+  sponsorlink: https://www.jit.io
+  year: 2023
+- item: Update to latest Crawljax
+  status: ⚡ In progress
+  year: 2023
 - item: Improve modern web app handling
   status: ⚡ In progress
-  year: 2022
+  year: 2023
 - item: Automation Framework enhancements
   status: ⚡ In progress
   url: https://github.com/zaproxy/zaproxy/issues/6461
-  year: 2022
-- item: "Networking: Initial HTTP/2 support"
-  status: ⚡ In progress
-  year: 2022
+  year: 2023
 - item: Move core functionality to add-ons
   status: ⚡ In progress
-  year: 2022
+  year: 2023
 - item: "OpenSSF Best Practices: Silver"
   status: ⚡ In progress
   url: https://bestpractices.coreinfrastructure.org/en/projects/24?criteria_level=1
-  year: 2022
-  
+  year: 2023
+
 - item: Continue working on issues
   status: ♻ Ongoing
   url: https://github.com/zaproxy/zaproxy/issues
@@ -48,6 +32,6 @@
   url: /docs/contribute/scan-rules/
   year: n/a
 
-- item: Networking changes in add-ons and maintenance
+- item: Release 2.13
   status: 🗓 Not started
   year: 2023

--- a/site/data/supporters.yaml
+++ b/site/data/supporters.yaml
@@ -99,3 +99,18 @@ bronze:
   - name: 'CREST'
     link: https://www.crest-approved.org/
     notes: $225 donation
+
+# In alphabetical order
+
+community:
+  - name: 'Airmannl'
+  - name: 'Catatonic Prime'
+  - name: 'Faraday'
+  - name: 'IOTHREAT'
+  - name: 'Mike'
+  - name: 'Microsoft'
+  - name: 'Mircea Mare'
+  - name: 'Nina King'
+  - name: 'Sage'
+  - name: 'Shenneo'
+  - name: 'Uri Fleyder Kotler'

--- a/site/layouts/page/supporters.html
+++ b/site/layouts/page/supporters.html
@@ -34,6 +34,14 @@
 {{ end }}
 </ul>
 
+<h2>Community</h2>
+
+<ul>
+{{ range $supporter := $.Site.Data.supporters.community }}
+    <li>{{ $supporter.name }}</li>
+{{ end }}
+</ul>
+
   </article>
 </section>
 {{ end }}

--- a/site/layouts/roadmap/list.html
+++ b/site/layouts/roadmap/list.html
@@ -16,6 +16,7 @@
             <tr>
                <th>Year</th>
                <th>Status</th>
+               <th>Sponsor</th>
                <th>Item</th>
             </tr>
          </thead>
@@ -24,6 +25,7 @@
                <tr>
                   <td align="center">{{ .year }}</td>
                   <td align="center">{{ .status }}</td>
+                  <td align="center"><a href="{{ .sponsorlink }}">{{ .sponsor }}</a></td>
                   <td>{{ if .url }} <a href="{{ .url }}">{{ .item }}</a> {{ else }} {{ .item }} {{ end }}</td>
                </tr>
             {{ end }}


### PR DESCRIPTION
We're probably missing a load of previous sponsors - the ones I've added come from https://github.com/OWASP/www-project-zap/blob/master/_data/ow_attributions.json
