### PR TITLE
Update DVWA auth script

### DIFF
--- a/site/content/faq/details/setting-up-zap-to-test-dvwa.md
+++ b/site/content/faq/details/setting-up-zap-to-test-dvwa.md
@@ -53,6 +53,9 @@ function sendAndReceive(helper, url, postData) {
     var requestUri = new org.apache.commons.httpclient.URI(url, true);
     var requestHeader = new org.parosproxy.paros.network.HttpRequestHeader(method, requestUri, "HTTP/1.0");
     msg.setRequestHeader(requestHeader);
+    if (postData) {
+        msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
+    }
 
     helper.sendAndReceive(msg);
 


### PR DESCRIPTION
Update the content-length if a POST request, since the header is not automatically added/updated when setting a body.
(This worked fine in older ZAP versions as the header ended up being added/updated by side effects.)