### PR TITLE
Add some SEO and accessibility improvements to home page

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -38,10 +38,10 @@
       </span>
       <ul class="flex footer-social">
         <li>
-          <a href="https://github.com/zaproxy/"> {{ partial "svg/social/github.svg"}}</a>
+          <a href="https://github.com/zaproxy/" aria-label="Go to ZAP's GitHub repo"> {{ partial "svg/social/github.svg"}}</a>
         </li>
         <li>
-            <a href="https://twitter.com/zaproxy"> {{ partial "svg/social/twitter.svg"}}</a>
+            <a href="https://twitter.com/zaproxy" aria-label="Follow ZAP on Twitter"> {{ partial "svg/social/twitter.svg"}}</a>
         </li>
       </ul>
     </div>

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -41,8 +41,8 @@
             {{ end }}
           {{ end }}
           <li id="search-menu">
-            <a class="toggler">
-              <img height="20" width="20" src="/img/search.svg" />
+            <a class="toggler" href="#">
+              <img height="20" width="20" src="/img/search.svg" alt="Search icon"/>
             </a>
   
             <form data-no-csrf action="/search">
@@ -57,10 +57,10 @@
       <div class="social-links header-social">
         <ul class="flex ai-c no-list-style m-10 px-20">
           <li>
-            <a href="https://github.com/zaproxy"> {{ partial "svg/social/github.svg"}}</a>
+            <a href="https://github.com/zaproxy" aria-label="Go to ZAP's GitHub repo"> {{ partial "svg/social/github.svg"}}</a>
           </li>
           <li>
-              <a href="https://twitter.com/zaproxy"> {{ partial "svg/social/twitter.svg"}}</a>
+              <a href="https://twitter.com/zaproxy" aria-label="Follow ZAP on Twitter"> {{ partial "svg/social/twitter.svg"}}</a>
           </li>
         </ul>
       </div>

--- a/site/layouts/partials/supporters.html
+++ b/site/layouts/partials/supporters.html
@@ -3,7 +3,7 @@
     <a href="{{ $supporter.link }}" class="pt-30 px-30 card flex jc-c ai-c fd-c br-def">
         {{ if $supporter.logo }}
         <div class="mb-30">
-            <img class="supporter-logo" src="{{ $supporter.logo }}" style="width:100%;" />
+            <img class="supporter-logo" src="{{ $supporter.logo }}" alt="{{ $supporter.name }} logo" style="width:100%;" />
         </div>
         {{ else }}
         <h3> {{ $supporter.name }} </h3>


### PR DESCRIPTION
I used the google's lighthouse tool to spot some improvements that could be done to the ZAP's home page.

## Changes:

- added aria-labels for links without text.
- added alt text for images.

## Lighthouse's score before:

![image](https://github.com/zaproxy/zaproxy-website/assets/71379045/0bf5a3bf-97b8-40fe-9f36-75ec96a8f6a9)

## Lighthouse's score after:

![image](https://github.com/zaproxy/zaproxy-website/assets/71379045/9179d70d-8c4a-43c1-a7a9-b0955bf0439a)

