### PR TITLE
Update AMF Support add-on help page

### DIFF
--- a/site/content/docs/desktop/addons/amf-support/_index.md
+++ b/site/content/docs/desktop/addons/amf-support/_index.md
@@ -9,8 +9,4 @@ cascade:
     version: 3.0.0
 ---
 
-# AMF Support
-
-Adds support for AMF messages.
-
-Displays decoded AMF requests and responses.
+This add-on has been retired.


### PR DESCRIPTION
Replace whole content and mention the add-on has been retired.