### PR TITLE
Update actions' versions

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Check with Hydra

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: sudo apt-get update && sudo apt-get install -y nginx && sudo systemctl start nginx
       
       - name: Install node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '20'
       
@@ -30,7 +30,7 @@ jobs:
       - run: google-chrome --headless --disable-gpu --screenshot --window-size=1280,1600 http://localhost
       
       - name: 'Upload screenshot'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: screenshots
           path: ./screenshot.png

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '20'
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: zaproxy-website
     - name: Checkout zaproxy.github.io
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: zaproxy/zaproxy.github.io
         persist-credentials: false

--- a/.github/workflows/zap-full-scan.yml
+++ b/.github/workflows/zap-full-scan.yml
@@ -10,7 +10,7 @@ jobs:
     name: Full Scan ZAP website
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
       - name: ZAP Scan

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -10,7 +10,7 @@ jobs:
     name: Scan ZAP website
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
       - name: ZAP Scan


### PR DESCRIPTION
Update the actions to latest versions, which should address warns about Node.js 12 no longer being supported.