### PR TITLE
Redirect old user guide pages

### DIFF
--- a/site/content/docs/desktop/start/features/globalexcludeurl.md
+++ b/site/content/docs/desktop/start/features/globalexcludeurl.md
@@ -1,25 +1,7 @@
 ---
-# This page was generated from the add-on.
 title: Globally Excluded URLs
 type: userguide
 weight: 13
 ---
 
-# Globally Excluded URLs
-
-Globally Excluded URLs are a set of Regular Expressions
-(regex) that ZAP ignores completely throughout the application.
-These URLs will not show up in the Proxy, Scanner, or Spider for
-ZAP. In addition, the URL regexs will be saved in the global
-configuration for ZAP and not inside of the session file. These
-URLs will persist between each use of ZAP.
-
-The regex for URLs are configured using the [Global
-Exclude URL screen](/docs/desktop/ui/dialogs/options/globalexcludeurl/) in the ZAP Options.
-
-## See also
-
-|   |                                           |                                       |
-|---|-------------------------------------------|---------------------------------------|
-|   | [UI Overview](/docs/desktop/ui/)          | for an overview of the user interface |
-|   | [Features](/docs/desktop/start/features/) | provided by ZAP                       |
+This page was [moved](/docs/desktop/addons/network/options/globalexclusions/).

--- a/site/content/docs/desktop/ui/dialogs/options/globalexcludeurl.md
+++ b/site/content/docs/desktop/ui/dialogs/options/globalexcludeurl.md
@@ -1,28 +1,7 @@
 ---
-# This page was generated from the add-on.
 title: Options Global Exclude URL screen
 type: userguide
 weight: 11
 ---
 
-# Options Global Exclude URL screen
-
-This screen allows you to configure the [Global
-Exclude URL](/docs/desktop/start/features/globalexcludeurl/) regexs in ZAP:
-
-### Regex
-
-A regex of the URL that ZAP will ignore. Click the buttons
-Add, Modify, or Remove to edit each regex.
-
-### Enabled
-
-If the box is checked, then this regex URL will be ignored by
-ZAP.
-
-## See also
-
-|   |                                                      |                                                 |
-|---|------------------------------------------------------|-------------------------------------------------|
-|   | [UI Overview](/docs/desktop/ui/)                     | for an overview of the user interface           |
-|   | [Options dialogs](/docs/desktop/ui/dialogs/options/) | for details of the other Options dialog screens |
+This page was [moved](/docs/desktop/addons/network/options/globalexclusions/).


### PR DESCRIPTION
Redirect the core pages that were superseded by the add-ons.

Part of zaproxy/zaproxy#7888.