### PR TITLE
Update images used in scans

### DIFF
--- a/site/content/docs/scans/crawlmaze.md
+++ b/site/content/docs/scans/crawlmaze.md
@@ -33,7 +33,7 @@ see Issue [#7152](https://github.com/zaproxy/zaproxy/issues/7152) for more detai
 
 #### Settings
 
-The latest [Live ZAP Docker image](https://hub.docker.com/r/owasp/zap2docker-live/) is run with the default settings against this app with the following exceptions:
+The latest [Nightly ZAP Docker image](https://github.com/zaproxy/zaproxy/pkgs/container/zaproxy) is run with the default settings against this app with the following exceptions:
 
 * The traditional Spider "maxDepth" is set to 10 to find the deeper links.
 * The number of browsers launched by the Ajax Spider is set to 10 to speed up the crawling.

--- a/site/content/docs/scans/firingrange.md
+++ b/site/content/docs/scans/firingrange.md
@@ -47,6 +47,6 @@ see Issue [#7122](https://github.com/zaproxy/zaproxy/issues/7122) for more detai
 
 #### Settings
 
-The latest [Live ZAP Docker image](https://hub.docker.com/r/owasp/zap2docker-live/) is run with the default settings against this app with the following exceptions:
+The latest [Nightly ZAP Docker image](https://github.com/zaproxy/zaproxy/pkgs/container/zaproxy) is run with the default settings against this app with the following exceptions:
 
 * The [XSS](/docs/alerts/40012/) rule is set to use LOW threshold in order to detect 2 cases which are not strictly vulnerable.

--- a/site/content/docs/scans/juiceshop.md
+++ b/site/content/docs/scans/juiceshop.md
@@ -33,4 +33,4 @@ exploration but which is not listed then please [raise an issue](https://github.
 
 #### Settings
 
-The latest [Live ZAP Docker image](https://hub.docker.com/r/owasp/zap2docker-live/) is run with the default settings against this app with no exceptions.
+The latest [Nightly ZAP Docker image](https://github.com/zaproxy/zaproxy/pkgs/container/zaproxy) is run with the default settings against this app with no exceptions.

--- a/site/content/docs/scans/ssti.md
+++ b/site/content/docs/scans/ssti.md
@@ -28,4 +28,4 @@ Note that the "Non Vulnerable" site _is_ actually vulnerable to XSS attacks :smi
 
 #### Settings
 
-The latest [Live ZAP Docker image](https://hub.docker.com/r/owasp/zap2docker-live/) is run with the default settings against this app with no exceptions.
+The latest [Nightly ZAP Docker image](https://github.com/zaproxy/zaproxy/pkgs/container/zaproxy) is run with the default settings against this app with no exceptions.

--- a/site/content/docs/scans/webseclab.md
+++ b/site/content/docs/scans/webseclab.md
@@ -34,4 +34,4 @@ If an alert is generated for a false positive then the test fails.
 
 #### Settings
 
-The latest [Live ZAP Docker image](https://hub.docker.com/r/owasp/zap2docker-live/) is run with the default settings against this app with no exceptions.
+The latest [Nightly ZAP Docker image](https://github.com/zaproxy/zaproxy/pkgs/container/zaproxy) is run with the default settings against this app with no exceptions.


### PR DESCRIPTION
Link to `zaproxy` container, the scans are now using the nightly image published to GHCR.

Ref: zapbot/zap-mgmt-scripts#155.