### PR TITLE
Update default name of Root CA cert and links

### DIFF
--- a/site/content/blog/2021-02-03-run-zap-without-java-using-docker-and-webswing/index.md
+++ b/site/content/blog/2021-02-03-run-zap-without-java-using-docker-and-webswing/index.md
@@ -51,15 +51,15 @@ Note that on Windows you will need to replace `$(pwd)` with the full current wor
 
 When you do this ZAP will create 2 files on your mapped drive:
 
-* `owasp_zap_root_ca.crt` - the public ZAP Root CA certificate
-* `owasp_zap_root_ca.key` - the private ZAP Root CA certificate
+* `zap_root_ca.crt` - the public ZAP Root CA certificate
+* `zap_root_ca.key` - the private ZAP Root CA certificate
 
 You will need to use 2 browsers / profiles - one to proxy through ZAP and one to control the ZAP Desktop that you can now access via [Webswing](https://www.webswing.org/).
 
 Launch the browser you want to proxy through ZAP (we recommend that you use a new browser profile e.g. in [Firefox](https://support.mozilla.org/en-US/kb/profile-manager-create-remove-switch-firefox-profiles) or [Chrome](https://support.google.com/chrome/answer/2364824?co=GENIE.Platform%3DDesktop&hl=en)) then point it at `http://localhost:8080/zap`
 
 Configure it to [proxy via ZAP](/docs/desktop/start/proxies/)
-and [import the public ZAP Root CA certificate](/docs/desktop/ui/dialogs/options/dynsslcert/#install) so that it is trusted to sign websites.
+and [import the public ZAP Root CA certificate](/docs/desktop/addons/network/options/servercertificates/#install) so that it is trusted to sign websites.
 
 And there you have it, a local browser proxying through ZAP which can handle https sites and another browser which has full control of the ZAP Desktop, all without having to install Java!
 

--- a/site/content/docs/docker/webswing.md
+++ b/site/content/docs/docker/webswing.md
@@ -40,7 +40,7 @@ When you do this ZAP will create 2 files on your mapped drive:
 * zap_root_ca.key - the private ZAP Root CA certificate
 
 You will then need to configure one of your browsers to [proxy via ZAP](/docs/desktop/start/proxies/) 
-and [import the public ZAP Root CA certificate](/docs/desktop/ui/dialogs/options/dynsslcert/#install) so that it is trusted to sign websites.
+and [import the public ZAP Root CA certificate](/docs/desktop/addons/network/options/servercertificates/#install) so that it is trusted to sign websites.
 
 It is recommended that you keep a separate browser profile for proxying through ZAP.
 

--- a/site/content/faq/how-can-i-use-zap-with-a-java-application-which-connects-to-a-web-service-over-ssl.md
+++ b/site/content/faq/how-can-i-use-zap-with-a-java-application-which-connects-to-a-web-service-over-ssl.md
@@ -6,20 +6,19 @@ weight: 4
 ---
 
 
-You'll need to [generate a dynamic root CA
-certificate](/docs/desktop/ui/dialogs/options/dynsslcert/).
+You'll need to [generate a root CA certificate](/docs/desktop/addons/network/options/servercertificates/#generate).
 
 Export it into a file.
 
 Import it in to the JRE cacerts keystore.
 
 Assuming the Java keytool is on the system path, JAVA_HOME is set to the
-location of a JRE and the Zaproxy CA cert is exported to
-"~/owasp_zap_root_ca.cer", then the command is:
+location of a JRE and the ZAP Root CA cert is exported to
+"~/zap_root_ca.cer", then the command is:
 
     
     
-     $ keytool -importcert -keystore $JAVA_HOME/lib/security/cacerts -file ~/owasp_zap_root_ca.cer -alias owasp_zap_root_ca
+     $ keytool -importcert -keystore $JAVA_HOME/lib/security/cacerts -file ~/zap_root_ca.cer -alias owasp_zap_root_ca
     
 
 When you run your application you'll need to make sure it's using ZAP as a


### PR DESCRIPTION
Use the latest default name of the exported root CA cert, tweak also wording/name.
Link to the latest user guide page.