### PR TITLE
Update Gradle's JVM args in IntelliJ IDEA dev steps

### DIFF
--- a/site/content/docs/developer/building-zap-with-intellij-idea.md
+++ b/site/content/docs/developer/building-zap-with-intellij-idea.md
@@ -18,12 +18,12 @@ Working with ZAP in IntelliJ IDEA may need a bit more Java resources for the Gra
 
 For Linux/OSX
 ```bash
-echo 'org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=1g' >> ~/.gradle/gradle.properties
+echo 'org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g' >> ~/.gradle/gradle.properties
 ```  
 
 For Windows
 ```powershell
-echo "org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=1g" >> %USERPROFILE%\.gradle\gradle.properties
+echo "org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g" >> %USERPROFILE%\.gradle\gradle.properties
 ```  
 
 ## Import the ZAP Repositories


### PR DESCRIPTION
The` -XX:MaxPermSize` option has been replaced by `-XX:MaxMetaspaceSize`.

```
-XX:MaxPermSize=size
    Sets the maximum permanent generation space size (in bytes). This option was deprecated in JDK 8 and superseded by the -XX:MaxMetaspaceSize option. 
```

Ref: [Removed Java Options | The java Command](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html)