### PR TITLE
Alerts - add CWE, WASC non-mobile

### DIFF
--- a/site/content/docs/alerts/_index.md
+++ b/site/content/docs/alerts/_index.md
@@ -16,3 +16,5 @@ Many alerts support [tags](/alerttags/) which allow you to see which alerts are 
 
 Some alerts are only relevant for specific [technologies](/techtags/) - if you know your target app does _not_ use some of these technologies then you can configure ZAP
 to skip those tests.
+
+The CWE and WASC columns are only shown on wider screens - if you are using a mobile phone then try turning your screen sideways if you want to see them.

--- a/site/layouts/alert/list.html
+++ b/site/layouts/alert/list.html
@@ -16,6 +16,8 @@
                <th data-suggest>Status</th>
                <th data-suggest>Risk</th>
                <th data-suggest>Type</th>
+               <th class='th-non-mobile'>CWE</th>
+               <th class='th-non-mobile'>WASC</th>
             </tr>
          </thead>
          <tbody>
@@ -26,6 +28,8 @@
                   <td>{{ .Params.status }}</td>
                   <td>{{ .Params.risk }}</td>
                   <td>{{ .Params.alerttype }}</td>
+                  <td class='td-non-mobile'>{{ .Params.cwe }}</td>
+                  <td class='td-non-mobile'>{{ .Params.wasc }}</td>
                </tr>
             {{ end }}
          </tbody>

--- a/src/css/_layout.scss
+++ b/src/css/_layout.scss
@@ -150,3 +150,13 @@ $grid_widths: 2 3 4 5 6 8;
 .embed-youtube iframe, .embed-youtube object, .embed-youtube embed { 
 	position: absolute; top: 0; left: 0; width: 100%; height: 100%; 
 }
+
+// Hide columns on smaller screens
+@media only screen and (max-width: 650px) {
+  td.td-non-mobile {
+    display:none;
+  }
+  th.th-non-mobile {
+    display:none;
+  }
+}


### PR DESCRIPTION
Add CWE and WASC columns in the Alerts list, but only for wider screens. Is this something we might want to do on other pages too?

Desktop

![Screenshot 2023-09-29 at 09-47-35 ZAP – ZAP Alert Details](https://github.com/zaproxy/zaproxy-website/assets/1081115/0a164263-8ed7-4ee1-88f3-d3e0bf12adb2)

Smaller screen

![Screenshot 2023-09-29 at 09-49-21 ZAP – ZAP Alert Details](https://github.com/zaproxy/zaproxy-website/assets/1081115/ae8ec0d5-c786-4dca-b993-005b4f89bb98)
