### PR TITLE
Tweak layout to avoid incrementing newlines

### DIFF
--- a/site/layouts/team/single.html
+++ b/site/layouts/team/single.html
@@ -11,9 +11,9 @@
 
 {{ $posts := where .Site.Pages "Type" "post" }}
 {{ range $posts}}
-	{{ if in .Params.authors $author }}
+	{{- if in .Params.authors $author -}}
 		{{ $.Scratch.Add "blogCounter" 1 }}
-	{{ end }}
+	{{- end -}}
 {{ end }}
 
 <div class="wrapper py-20" data-kind="{{ .Kind }}">


### PR DESCRIPTION
Use the syntax that trims whitespace in the teams single layout to prevent newlines being added on each new post.

---
Reported in IRC.