### PR TITLE
Add PWD examples for multiple platforms.

### DIFF
--- a/site/content/docs/docker/about.md
+++ b/site/content/docs/docker/about.md
@@ -65,6 +65,32 @@ If you are running ZAP with port other than the default `8080`, you need to set 
 
 ## Usage Instructions
 
+### Mounting the Current Directory
+Many of the examples require that you mount the `/zap/wrk` directory, and these examples show how you can mount your **[current working directory](https://en.wikipedia.org/wiki/Working_directory) (CWD)**.
+One can _get_ the CWD using various forms of _printing_ the (current) working directory (PWD).
+
+```bash
+# ...linux / MacOS / PowerShell
+#    The $(pwd) command substitution will get the current directory as a variable
+#    The classic form `pwd` must be used for csh and tsch / is still supported in bash/zsh/etc.
+docker run -v $(pwd):/zap/wrk/:rw -t softwaresecurityproject/zap-stable zap.sh ...
+
+# ...linux / MacOS / PowerShell
+#    The ${PWD} _environment variable_ is your current directory
+docker run -v ${PWD}:/zap/wrk/:rw -t softwaresecurityproject/zap-stable zap.sh ...
+
+# ...windows CMD
+#    The %cd% Windows CMD environment variable is your current directory
+docker run -v %cd%:/zap/wrk/:rw -t softwaresecurityproject/zap-stable zap.sh ...
+```
+
+The examples use `$(pwd)` [command substitution](https://en.wikipedia.org/wiki/Command_substitution), which runs the `pwd` command, substituting the _result_.
+Command substitution, and the `pwd` command works in _most_ Linux and MacOS shells (bash, zsh, fish(>3.4.0), etc), and in Windows PowerShell.
+
+Many environments _also_ support the $PWD / ${PWD} _environment variable_.
+
+Finding working solutions for _all_ environments is outside the scope of this document.
+
 ### Packaged Scans
 All of the docker images (apart from the 'bare' one) provide a set of packaged scan scripts:
 
@@ -106,7 +132,11 @@ You can run the Automation Framework in docker using the zap.yaml file in the cu
 ```bash
 docker run -v $(pwd):/zap/wrk/:rw -t softwaresecurityproject/zap-stable zap.sh -cmd -autorun /zap/wrk/zap.yaml
 ```
-Note that `$(pwd)` is only supported on Linux and MacOS - on Windows you will need to replace this with the full current working directory (ex: `C:\your\working\directory\`).
+
+Note that `$(pwd)` is supported on Linux, MacOS and PowerShell.
+See [Docker About - Mounting the current directory](/docs/docker/about/#mounting-the-current-directory) for Windows, etc.
+
+Remaining examples use the Linux approach.
 
 If you want to make sure that ZAP is up to date before running the yaml file then the recommended approach is:
 

--- a/site/content/docs/docker/baseline-scan.md
+++ b/site/content/docs/docker/baseline-scan.md
@@ -58,7 +58,8 @@ docker run -v $(pwd):/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable zap-baseline
     -t https://www.example.com -g gen.conf -r testreport.html
 ```
 
-Note that `$(pwd)` is only supported on Linux and MacOS - on Windows you will need to replace this with the full current working directory.
+Note that `$(pwd)` is supported on Linux, MacOS and PowerShell.
+See [Docker About - Mounting the current directory](/docs/docker/about/#mounting-the-current-directory) for Windows, etc.
 
 ### Example Output
 ```

--- a/site/content/docs/docker/diagnosing-problems.md
+++ b/site/content/docs/docker/diagnosing-problems.md
@@ -31,7 +31,8 @@ For the packaged scans you need to map a drive to `/zap/wrk`.
 
 On Linux / MacOS you can do this using the Docker option `-v $(pwd):/zap/wrk/:rw`.
 
-On Windows you need to specify the full local directory name e.g. `-v C:\temp:/zap/wrk/:rw`.
+Note that `$(pwd)` is supported on Linux, MacOS and PowerShell.
+See [Docker About - Mounting the current directory](/docs/docker/about/#mounting-the-current-directory) for Windows, etc.
 
 If you cannot see files that should be being created then first check to make sure they are created in the mapped drive.
 

--- a/site/content/docs/docker/full-scan.md
+++ b/site/content/docs/docker/full-scan.md
@@ -56,7 +56,8 @@ docker run -v $(pwd):/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable zap-full-sca
     -t https://www.example.com -g gen.conf -r testreport.html
 ```
 
-Note that `$(pwd)` is only supported on Linux and MacOS - on Windows you will need to replace this with the full current working directory.
+Note that `$(pwd)` is supported on Linux, MacOS and PowerShell.
+See [Docker About - Mounting the current directory](/docs/docker/about/#mounting-the-current-directory) for Windows, etc.
 
 ### Scan Hooks
 This script supports [scan hooks](../scan-hooks/) which allow you to override or modify behaviour of the script components instead of having to write a new script.

--- a/site/content/docs/docker/scan-hooks.md
+++ b/site/content/docs/docker/scan-hooks.md
@@ -52,7 +52,8 @@ docker run -v $(pwd):/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable zap-baseline
     -t https://www.example.com -g gen.conf -r testreport.html --hook=/zap/wrk/my-hooks.py
 ```
 
-Note that `$(pwd)` is only supported on Linux and MacOS - on Windows you will need to replace this with the full current working directory.
+Note that `$(pwd)` is supported on Linux, MacOS and PowerShell.
+See [Docker About - Mounting the current directory](/docs/docker/about/#mounting-the-current-directory) for Windows, etc.
 
 ## Example Hooks
 See https://github.com/zaproxy/community-scripts/tree/main/other/scan-hooks

--- a/site/content/docs/docker/webswing.md
+++ b/site/content/docs/docker/webswing.md
@@ -39,6 +39,9 @@ When you do this ZAP will create 2 files on your mapped drive:
 * zap_root_ca.crt - the public ZAP Root CA certificate
 * zap_root_ca.key - the private ZAP Root CA certificate
 
+Note that `$(pwd)` is supported on Linux, MacOS and PowerShell.
+See [Docker About - Mounting the current directory](/docs/docker/about/#mounting-the-current-directory) for Windows, etc.
+
 You will then need to configure one of your browsers to [proxy via ZAP](/docs/desktop/start/proxies/) 
 and [import the public ZAP Root CA certificate](/docs/desktop/addons/network/options/servercertificates/#install) so that it is trusted to sign websites.
 


### PR DESCRIPTION
Add `docker run ...` examples when mounting the current directory as a volume in the container.

The examples show how to do this on Linux/MacOS (as before), PowerShell and Windows.

Resolves #2275