### PR TITLE
Fix search index

### DIFF
--- a/site/layouts/page/search.json
+++ b/site/layouts/page/search.json
@@ -22,7 +22,7 @@
 
     {
     "url": "{{ .Permalink }}",
-    "title": "{{ .Title }}",
+    "title": {{ .Title | jsonify }},
     "keywords": {{ $keywords }},
     "tags": {{ .Param "tags" | jsonify }},
     "summary": {{ .Summary | jsonify }},


### PR DESCRIPTION
Output the title as JSON otherwise it would generate malformed JSON and break the search functionality when the title had double quotes.

---
Spotted by @psiinon :)