### PR TITLE
Change search button pointer

### DIFF
--- a/site/layouts/page/search.html
+++ b/site/layouts/page/search.html
@@ -11,7 +11,7 @@
   <article class="content single-default">
     <form data-no-csrf class="p-20 bg--blue-lightest flex">
       <input type="text" name="q" id="search-filter" placeholder="Search ..." class="fx-g-1" />
-      <button type="button" id="search-trigger" class=" ml-10" >Search</button>
+      <button type="button" id="search-trigger" class="ml-10 search-button" >Search</button>
     </form>
     <br/>
     <main id="search-results"></main>

--- a/src/css/_navigation.scss
+++ b/src/css/_navigation.scss
@@ -166,6 +166,10 @@ input {
 
 }
 
+.search-button {
+  cursor: pointer;
+}
+
 .download-button {
   margin-top: 4px;
 }


### PR DESCRIPTION
The mouse pointer doesnt change when it hovers over the Search button, unlike the other buttons (e.g. Download).
This could confuse people into thinking it doesnt work.

https://www.zaproxy.org/search/?q=test