### PR TITLE
Video: ZAP Chat 14 GSoC

### DIFF
--- a/site/content/docs/gsoc/_index.md
+++ b/site/content/docs/gsoc/_index.md
@@ -52,3 +52,4 @@ cascade:
 
 [Google Summer of Code](http://g.co/gsoc) has been a great program for ZAP and has led to many key features being developed.
 
+{{<youtube uuid="Cm_ol-PA738" small="true">}}

--- a/site/content/docs/team/psiinon.md
+++ b/site/content/docs/team/psiinon.md
@@ -43,6 +43,7 @@ All of Simon’s publicly available videos are linked off the [Videos](/videos/)
 
 #### Interviews and Panels
 
+* 2023/01/04 [IWCON2023: A decade plus of maintaining ZAP - Simon Bennetts](https://www.youtube.com/watch?v=pQLd7Qka330)
 * 2023/10/25 [Evo Cyber Security #51 – Changes in Software Supply Chain Regulations](https://evolutionjobs.com/exchange/evo-cyber-security-51-changes-in-software-supply-chain-regulations/)
 * 2023/09/12 [Application Security Weekly: Building a Scanner and a Community with Zed Attack Proxy - Simon Bennetts - ASW #254](https://www.youtube.com/watch?v=alIBoz7AooI)
 * 2023/06/14 [Software Engineering Radio 568: Simon Bennetts on OWASP Dynamic Application Security Testing Tool ZAP](https://www.se-radio.net/2023/06/se-radio-568-simon-bennetts-on-owasp-dynamic-application-security-testing-tool-zap/)

--- a/site/content/zap-chat.md
+++ b/site/content/zap-chat.md
@@ -42,6 +42,9 @@ links:
   - name: '13 2023 Review'
     uuid: VPVuxftv99A
 
+  - name: '14 Google Summer of Code'
+    uuid: Cm_ol-PA738
+
 ---
 A new and ongoing [set of videos](https://www.youtube.com/playlist?list=PLEBitBW-HlsvFEfyWdpLe6IlQoitjaPCX) focusing on ZAP features, new and old.
 

--- a/site/data/videos.yaml
+++ b/site/data/videos.yaml
@@ -4,6 +4,15 @@
 
 # ZAP Chat Series
 
+- title: 'ZAP Chat 14 Google Summer of Code'
+  id: Cm_ol-PA738
+  site: youtube
+  series: 'ZAP Chat'
+  date: '2024/01/10'
+  length: 27:10
+  tags:
+  - gsoc
+
 - title: 'ZAP Chat 13 2023 Review'
   id: VPVuxftv99A
   site: youtube

--- a/site/layouts/shortcodes/youtube.html
+++ b/site/layouts/shortcodes/youtube.html
@@ -1,3 +1,5 @@
+{{ if isset .Params `small` }}<div class="grid grid__two-col grid_row_gap">{{ end }}
 <div class='embed-youtube'>
-  <iframe src='https://www.youtube.com/embed/{{ .Get "uuid" }}' frameborder='0' allowfullscreen></iframe>
+<iframe src='https://www.youtube.com/embed/{{ .Get "uuid" }}' frameborder='0' allowfullscreen></iframe>
 </div>
+{{ if isset .Params `small` }}</div>{{ end }}


### PR DESCRIPTION
Adding `small="anything"` to a youtube video shortcode will make the video smaller on the desktop but wont affect the sixe on mobile.
I think it looks better like that on the GSoC page..

<details><summary>Screenshot</summary>
<p>

![Screenshot 2024-01-10 at 16-42-59 ZAP – Google Summer of Code](https://github.com/zaproxy/zaproxy-website/assets/1081115/0472f0b4-48f6-4a8d-b30e-d0743bce0e71)

</p>
</details> 

