### PR TITLE
Skip branch pages when generating userguide TOC

### DIFF
--- a/site/layouts/partials/tree.html
+++ b/site/layouts/partials/tree.html
@@ -37,7 +37,7 @@
     {{- if not $deprecated }}
         <ul class="tree-branch">
         {{- range (readDir .path) }}
-            {{- if in .Name "image" }}
+            {{- if in .Name "image" | or (eq .Name "_index.md") }}
             {{- else }}
                 {{- $fullPath := (printf "%s/%s" $.path .Name) }}
                 {{- $fullUrl := replace $fullPath "/content" "" }}


### PR DESCRIPTION
The branch pages are already listed as parent of the leaf pages.