### PR TITLE
Group dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,11 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  groups:
+    dependencies:
+      applies-to: version-updates
+      update-types:
+      - "minor"
+      - "patch"
+      patterns:
+      - "*"


### PR DESCRIPTION
Raise just one pull request when updating minor/patch version updates, to reduce the workload with the many uninteresting pull requests.