### PR TITLE
Fix Requester Spelling

### DIFF
--- a/site/data/burp2zap.yaml
+++ b/site/data/burp2zap.yaml
@@ -51,7 +51,7 @@
   comNotes:
   zap1: Manual Request Editor
   zap1Link:
-  zap2: Requestor Add-on
+  zap2: Requester Add-on
   zap2Link: /docs/desktop/addons/requester/
 - burp: Scanner
   comSupport: false


### PR DESCRIPTION
Everywhere else "Requester" is used instead of "Requestor"

With 💚 from Tecvity