### PR TITLE
Run dependabot weekly rather than daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   groups:
     dependencies:
       applies-to: version-updates


### PR DESCRIPTION
The dependencies don't need to be updated everyday and with the grouped updates it does not lead to much work if there are many to update at the same time.