### PR TITLE
Update alert pages for script scan rules

### DIFF
--- a/site/content/docs/alerts/100002.md
+++ b/site/content/docs/alerts/100002.md
@@ -1,0 +1,23 @@
+---
+title: "Server is running on Clacks - GNU Terry Pratchett"
+alertid: 100002
+alertindex: 10000200
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Informational
+solution: "Give the sysadmin a high five and rejoice in the disc world."
+references:
+   - https://xclacksoverhead.org/home/about
+other: ""
+cwe: 200
+wasc: 13
+alerttags: 
+  - CWE-200
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/clacks.js
+linktext: "passive/clacks.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+The web/application server is running over the Clacks network, some say it's turtles/IP,  some say it's turtles all the way down the layer stack.
+

--- a/site/content/docs/alerts/100003.md
+++ b/site/content/docs/alerts/100003.md
@@ -1,0 +1,19 @@
+---
+title: "Cookie Set Without HttpOnly Flag"
+alertid: 100003
+alertindex: 10000300
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Low
+solution: "Ensure that the HttpOnly flag is set for all cookies."
+other: ""
+wasc: 13
+alerttags: 
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/CookieHTTPOnly.js
+linktext: "passive/CookieHTTPOnly.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
+

--- a/site/content/docs/alerts/100004.md
+++ b/site/content/docs/alerts/100004.md
@@ -1,0 +1,22 @@
+---
+title: "Content Security Policy Violations Reporting Enabled"
+alertid: 100004
+alertindex: 10000400
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Informational
+solution: "Site owner will be notified at each policies violations, so, start by analyzing if a real monitoring of the notifications is in place before to use fuzzing or to be more aggressive. "
+references:
+   - https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_CSP_violation_reports
+other: ""
+cwe: 200
+wasc: 13
+alerttags: 
+  - CWE-200
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/detect_csp_notif_and_reportonly.js
+linktext: "passive/detect_csp_notif_and_reportonly.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+

--- a/site/content/docs/alerts/100005.md
+++ b/site/content/docs/alerts/100005.md
@@ -1,0 +1,23 @@
+---
+title: "SameSite Cookie Attribute Protection Used"
+alertid: 100005
+alertindex: 10000500
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Informational
+solution: "CSRF possible vulnerabilities presents on the site will be mitigated depending on the browser used by the user (browser defines the support level for this cookie attribute). "
+references:
+   - https://tools.ietf.org/html/draft-west-first-party-cookies
+   - https://chloe.re/2016/04/13/goodbye-csrf-samesite-to-the-rescue
+other: ""
+cwe: 352
+wasc: 9
+alerttags: 
+  - CWE-352
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/detect_samesite_protection.js
+linktext: "passive/detect_samesite_protection.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+

--- a/site/content/docs/alerts/100006.md
+++ b/site/content/docs/alerts/100006.md
@@ -1,0 +1,23 @@
+---
+title: "Information Disclosure - IP Exposed via F5 BIG-IP Persistence Cookie"
+alertid: 100006
+alertindex: 10000600
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Informational
+solution: "Configure BIG-IP cookie encryption."
+references:
+   - https://support.f5.com/kb/en-us/solutions/public/6000/900/sol6917.html
+other: ""
+cwe: 311
+wasc: 13
+alerttags: 
+  - CWE-311
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/f5_bigip_cookie_internal_ip.js
+linktext: "passive/f5_bigip_cookie_internal_ip.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+The F5 BIG-IP Persistence cookie set for this website can be decoded to a specific IP and port. An attacker may leverage this information to conduct Social Engineering attacks or other exploits.
+

--- a/site/content/docs/alerts/100007.md
+++ b/site/content/docs/alerts/100007.md
@@ -1,0 +1,21 @@
+---
+title: "Information Disclosure - Base64-encoded String"
+alertid: 100007
+alertindex: 10000700
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Informational
+solution: "Base64-encoding should not be used to store or send sensitive information."
+other: ""
+cwe: 311
+wasc: 13
+alerttags: 
+  - CWE-311
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/find%20base64%20strings.js
+linktext: "passive/find base64 strings.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A Base64-encoded string has been found in the HTTP response body. Base64-encoded data may contain sensitive information such as usernames, passwords or cookies which should be further inspected.
+

--- a/site/content/docs/alerts/100008.md
+++ b/site/content/docs/alerts/100008.md
@@ -1,0 +1,20 @@
+---
+title: "Information Disclosure - Credit Card Number"
+alertid: 100008
+alertindex: 10000800
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: High
+solution: "Encrypt credit card numbers during transmission, use tokenization, and adhere to PCI DSS standards for secure handling and storage. "
+other: ""
+cwe: 311
+wasc: 13
+alerttags: 
+  - CWE-311
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Find%20Credit%20Cards.js
+linktext: "passive/Find Credit Cards.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A credit card number was found in the HTTP response body.

--- a/site/content/docs/alerts/100009.md
+++ b/site/content/docs/alerts/100009.md
@@ -1,0 +1,21 @@
+---
+title: "Information Disclosure - Email Addresses"
+alertid: 100009
+alertindex: 10000900
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Low
+solution: "Mask email addresses during transmission and ensure proper access controls  to protect user privacy and prevent unauthorized access. "
+other: ""
+cwe: 311
+wasc: 13
+alerttags: 
+  - CWE-311
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Find%20Emails.js
+linktext: "passive/Find Emails.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+An email address was found in the HTTP response body. Exposure of email addresses in HTTP messages can lead to privacy violations  and targeted phishing attacks.
+

--- a/site/content/docs/alerts/100010.md
+++ b/site/content/docs/alerts/100010.md
@@ -1,0 +1,20 @@
+---
+title: "Information Disclosure - Hash"
+alertid: 100010
+alertindex: 10001000
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Low
+solution: "Ensure that hashes that are used to protect credentials or other resources are not leaked by the web server or database. There is typically no requirement for password hashes to be accessible to the web browser. "
+other: ""
+cwe: 327
+wasc: 13
+alerttags: 
+  - CWE-327
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Find%20Hashes.js
+linktext: "passive/Find Hashes.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A hash was discovered in the HTTP response body.

--- a/site/content/docs/alerts/100011.md
+++ b/site/content/docs/alerts/100011.md
@@ -1,0 +1,21 @@
+---
+title: "Information Disclosure - HTML Comments"
+alertid: 100011
+alertindex: 10001100
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Informational
+solution: "Remove comments which have sensitive information about the design/implementation of the application. Some of the comments may be exposed to the user and affect  the security posture of the application. "
+other: ""
+cwe: 615
+wasc: 13
+alerttags: 
+  - CWE-615
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Find%20HTML%20Comments.js
+linktext: "passive/Find HTML Comments.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+While adding general comments is very useful, some programmers tend to leave important data, such as: filenames related to the web application, old links or links which were not meant to be browsed by users, old code fragments, etc.
+

--- a/site/content/docs/alerts/100012.md
+++ b/site/content/docs/alerts/100012.md
@@ -1,0 +1,20 @@
+---
+title: "Information Disclosure - IBAN Numbers"
+alertid: 100012
+alertindex: 10001200
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Low
+solution: "Investigate IBAN numbers found in the response, remove or mask as required."
+other: ""
+cwe: 200
+wasc: 13
+alerttags: 
+  - CWE-200
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Find%20IBANs.js
+linktext: "passive/Find IBANs.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+An IBAN number was discovered in the HTTP response body.

--- a/site/content/docs/alerts/100013.md
+++ b/site/content/docs/alerts/100013.md
@@ -1,0 +1,21 @@
+---
+title: "Information Disclosure - Private IP Address"
+alertid: 100013
+alertindex: 10001300
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Medium
+solution: "Remove the private IP address from the HTTP response body. For comments, use JSP/ASP comment instead of HTML/JavaScript comment which can be seen by client browsers. "
+other: ""
+cwe: 200
+wasc: 13
+alerttags: 
+  - CWE-200
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Find%20Internal%20IPs.js
+linktext: "passive/Find Internal IPs.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A private IP such as 10.x.x.x, 172.x.x.x, 192.168.x.x or IPV6 fe00:: has been found in the HTTP response body. This information might be helpful for further attacks targeting internal systems.
+

--- a/site/content/docs/alerts/100014.md
+++ b/site/content/docs/alerts/100014.md
@@ -6,11 +6,16 @@ alerttype: "Script Passive"
 alertcount: 1
 status: alpha
 type: alert
-solution: "_Unavailable_"
+risk: Informational
+solution: ""
 other: ""
+cwe: 79
+wasc: 8
 alerttags: 
+  - CWE-79
 code: https://github.com/zaproxy/community-scripts/blob/main/passive/find_reflected_params.py
 linktext: "passive/find_reflected_params.py"
 help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
 ---
-_Unavailable_
+A reflected parameter value has been found in the HTTP response. Reflected parameter values may introduce XSS vulnerability or HTTP header injection.
+

--- a/site/content/docs/alerts/100015.md
+++ b/site/content/docs/alerts/100015.md
@@ -6,11 +6,13 @@ alerttype: "Script Passive"
 alertcount: 1
 status: alpha
 type: alert
-solution: "_Unavailable_"
+risk: Informational
+solution: ""
 other: ""
 alerttags: 
 code: https://github.com/zaproxy/community-scripts/blob/main/passive/HUNT.py
 linktext: "passive/HUNT.py"
 help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
 ---
-_Unavailable_
+Find possible vulnerable entry points using HUNT Methodology (https://github.com/bugcrowd/HUNT).
+

--- a/site/content/docs/alerts/100016.md
+++ b/site/content/docs/alerts/100016.md
@@ -1,0 +1,21 @@
+---
+title: "Missing Security Headers"
+alertid: 100016
+alertindex: 10001600
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Low
+solution: "Ensure that your web server, application server, load balancer, etc. is configured to set the missing security headers. "
+other: ""
+cwe: 693
+wasc: 15
+alerttags: 
+  - CWE-693
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Mutliple%20Security%20Header%20Check.js
+linktext: "passive/Mutliple Security Header Check.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+Some of the following security headers are missing from the HTTP response: Strict-Transport-Security, Content-Security-Policy, X-XSS-Protection, X-Content-Type-Options, X-Frame-Options.
+

--- a/site/content/docs/alerts/100017.md
+++ b/site/content/docs/alerts/100017.md
@@ -1,0 +1,18 @@
+---
+title: "Non Static Site Detected"
+alertid: 100017
+alertindex: 10001700
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Informational
+solution: "If this is not a static site then ignore or disable this rule. "
+other: ""
+alerttags: 
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Report%20non%20static%20sites.js
+linktext: "passive/Report non static sites.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A query string or form has been detected in the HTTP response body. This indicates that this may not be a static site.
+

--- a/site/content/docs/alerts/100018.md
+++ b/site/content/docs/alerts/100018.md
@@ -1,0 +1,21 @@
+---
+title: "Relative Path Overwrite"
+alertid: 100018
+alertindex: 10001800
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Medium
+solution: "Use absolute paths in URLs and resources to prevent manipulation. Validate and sanitize all user inputs that are used to construct URLs. "
+other: ""
+cwe: 20
+wasc: 13
+alerttags: 
+  - CWE-20
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/RPO.js
+linktext: "passive/RPO.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+Potential RPO (Relative Path Overwrite) found. RPO allows attackers to manipulate URLs to include unintended paths, potentially leading to the execution of malicious scripts or the disclosure of sensitive information.
+

--- a/site/content/docs/alerts/100019.md
+++ b/site/content/docs/alerts/100019.md
@@ -1,0 +1,21 @@
+---
+title: "Information Disclosure - Server Header"
+alertid: 100019
+alertindex: 10001900
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Low
+solution: "Ensure that your web server, application server, load balancer, etc. is configured to suppress the 'Server' header  or provide generic details. "
+other: ""
+cwe: 200
+wasc: 13
+alerttags: 
+  - CWE-200
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Server%20Header%20Disclosure.js
+linktext: "passive/Server Header Disclosure.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+The web/application server is leaking version information via the 'Server' HTTP response header. Access to such information may facilitate attackers identifying other vulnerabilities your web/application server  is subject to.
+

--- a/site/content/docs/alerts/100020.md
+++ b/site/content/docs/alerts/100020.md
@@ -1,0 +1,20 @@
+---
+title: "Information Disclosure - SQL Error"
+alertid: 100020
+alertindex: 10002000
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: High
+solution: "Ensure proper sanitisation is done on the server side. "
+other: ""
+cwe: 209
+wasc: 13
+alerttags: 
+  - CWE-209
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/SQL%20injection%20detection.js
+linktext: "passive/SQL injection detection.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+An SQL error was found in the HTTP response body.

--- a/site/content/docs/alerts/100021.md
+++ b/site/content/docs/alerts/100021.md
@@ -1,0 +1,25 @@
+---
+title: "Telerik UI for ASP.NET AJAX Cryptographic Weakness (CVE-2017-9248)"
+alertid: 100021
+alertindex: 10002100
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: High
+solution: "See https://docs.telerik.com/devtools/aspnet-ajax/knowledge-base/common-cryptographic-weakness for update/mitigation guidance. "
+references:
+   - https://docs.telerik.com/devtools/aspnet-ajax/knowledge-base/common-cryptographic-weakness
+other: ""
+cwe: 327
+wasc: 13
+alerttags: 
+  - CWE-327
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Telerik%20Using%20Poor%20Crypto.js
+linktext: "passive/Telerik Using Poor Crypto.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A request has been made that appears to conform to poor cryptography used by Telerik UI for ASP.NET AJAX prior to v2017.2.621.
+An attacker could manipulate the value of the dp parameter to possibly learn the machine key and upload arbitrary files, which could then lead to the compromise of ASP.NET ViewStates and arbitrary code execution respectively.
+CVE-2017-9248 has a CVSSv3 score of 9.8.
+

--- a/site/content/docs/alerts/100022.md
+++ b/site/content/docs/alerts/100022.md
@@ -1,0 +1,21 @@
+---
+title: "Upload Form Discovered"
+alertid: 100022
+alertindex: 10002200
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Informational
+solution: "Implement strict validation and restrictions on uploaded files, including file type, size, and content. Use security measures like antivirus scanning and file storage outside the web root. "
+other: ""
+cwe: 434
+wasc: 20
+alerttags: 
+  - CWE-434
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/Upload%20form%20discovery.js
+linktext: "passive/Upload form discovery.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+The presence of a file upload form can lead to various security vulnerabilities, such as uploading malicious files or overwriting existing files, if proper validation and restrictions are not implemented. This can result in unauthorized code execution, data breaches, or denial of service attacks.
+

--- a/site/content/docs/alerts/100023.md
+++ b/site/content/docs/alerts/100023.md
@@ -1,0 +1,21 @@
+---
+title: "Information Disclosure - X-Powered-By Header"
+alertid: 100023
+alertindex: 10002300
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Low
+solution: "Ensure that your web server, application server, load balancer, etc. is configured to suppress 'X-Powered-By' headers. "
+other: ""
+cwe: 200
+wasc: 13
+alerttags: 
+  - CWE-200
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/X-Powered-By_header_checker.js
+linktext: "passive/X-Powered-By_header_checker.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+The web/application server is leaking information via one or more 'X-Powered-By' HTTP response headers. Access to such information may facilitate attackers identifying other frameworks/components your web application is reliant upon and the vulnerabilities such components may be subject to.
+

--- a/site/content/docs/alerts/100025.md
+++ b/site/content/docs/alerts/100025.md
@@ -1,0 +1,25 @@
+---
+title: "Cross-Site WebSocket Hijacking"
+alertid: 100025
+alertindex: 10002500
+alerttype: "Script Active"
+alertcount: 1
+status: alpha
+type: alert
+risk: High
+solution: "Validate Origin header on WebSocket connection handshake, to ensure only specified origins are allowed to connect. Also, WebSocket handshake should use random tokens, similar to anti CSRF tokens. "
+references:
+   - https://tools.ietf.org/html/rfc6455#section-10.2
+other: "See also https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking or https://christian-schneider.net/CrossSiteWebSocketHijacking.html "
+cwe: 346
+wasc: 9
+alerttags: 
+  - CWE-346
+  - OWASP_2017_A05
+  - OWASP_2021_A01
+  - WSTG-v42-CLNT-10
+code: https://github.com/zaproxy/community-scripts/blob/main/active/Cross%20Site%20WebSocket%20Hijacking.js
+linktext: "active/Cross Site WebSocket Hijacking.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+Server accepted WebSocket connection through HTTP Upgrade request with modified Origin header.

--- a/site/content/docs/alerts/100026.md
+++ b/site/content/docs/alerts/100026.md
@@ -1,0 +1,26 @@
+---
+title: "JWT None Exploit"
+alertid: 100026
+alertindex: 10002600
+alerttype: "Script Active"
+alertcount: 1
+status: alpha
+type: alert
+risk: High
+solution: "Use a secure JWT library, and (if your library supports it) restrict the allowed hash algorithms. "
+references:
+   - https://www.sjoerdlangkemper.nl/2016/09/28/attacking-jwt-authentication/
+other: ""
+cwe: 347
+wasc: 15
+alerttags: 
+  - CWE-347
+  - OWASP_2017_A02
+  - OWASP_2021_A01
+  - WSTG-v42-CRYP-04
+code: https://github.com/zaproxy/community-scripts/blob/main/active/JWT%20None%20Exploit.js
+linktext: "active/JWT None Exploit.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+The application's JWT implementation allows for the usage of the 'none' algorithm, which bypasses the JWT hash verification.
+

--- a/site/content/docs/alerts/100029.md
+++ b/site/content/docs/alerts/100029.md
@@ -1,0 +1,27 @@
+---
+title: "File Content Disclosure (CVE-2019-5418)"
+alertid: 100029
+alertindex: 10002900
+alerttype: "Script Active"
+alertcount: 1
+status: alpha
+type: alert
+risk: High
+solution: "Upgrade to a version of Ruby/Rails where this issue is fixed. (See references for further details). "
+references:
+   - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5418
+   - https://github.com/mpgn/CVE-2019-5418
+other: ""
+cwe: 74
+wasc: 33
+alerttags: 
+  - CWE-74
+  - OWASP_2017_A01
+  - OWASP_2021_A03
+  - WSTG-v42-ATHZ-01
+code: https://github.com/zaproxy/community-scripts/blob/main/active/cve-2019-5418.js
+linktext: "active/cve-2019-5418.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+The application seems to be subject to CVE-2019-5418. By sending a specially crafted request it was possible to have the target return data from the server file system.
+

--- a/site/content/docs/alerts/100030.md
+++ b/site/content/docs/alerts/100030.md
@@ -1,0 +1,24 @@
+---
+title: "Backup File Detected"
+alertid: 100030
+alertindex: 10003000
+alerttype: "Script Active"
+alertcount: 1
+status: alpha
+type: alert
+risk: Low
+solution: "Ensure that backups are made in locations which are not web accessible."
+other: ""
+cwe: 425
+wasc: 34
+alerttags: 
+  - CWE-425
+  - OWASP_2017_A06
+  - OWASP_2021_A05
+  - WSTG-v42-CONF-04
+code: https://github.com/zaproxy/community-scripts/blob/main/active/gof_lite.js
+linktext: "active/gof_lite.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A backup or alternate version of a page or component was detected. An attacker may leverage information in such files to further attack or abuse the system.
+

--- a/site/content/docs/alerts/100034.md
+++ b/site/content/docs/alerts/100034.md
@@ -1,0 +1,20 @@
+---
+title: "Information Disclosure - Google API Key"
+alertid: 100034
+alertindex: 10003400
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Informational
+solution: "Ensure the API key is not overly permissive."
+other: ""
+cwe: 200
+wasc: 13
+alerttags: 
+  - CWE-200
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/google_api_keys_finder.js
+linktext: "passive/google_api_keys_finder.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A Google API Key was found in the HTTP response body.

--- a/site/content/docs/alerts/100035.md
+++ b/site/content/docs/alerts/100035.md
@@ -1,0 +1,20 @@
+---
+title: "Information Disclosure - Java Stack Trace"
+alertid: 100035
+alertindex: 10003500
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Medium
+solution: "Catch and handle exceptions properly, avoiding the exposure of stack traces to users. Configure the web server or application framework to log stack traces instead of displaying them. "
+other: ""
+cwe: 209
+wasc: 13
+alerttags: 
+  - CWE-209
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/JavaDisclosure.js
+linktext: "passive/JavaDisclosure.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+A Java stack trace was found in the HTTP response body.

--- a/site/content/docs/alerts/100036.md
+++ b/site/content/docs/alerts/100036.md
@@ -1,0 +1,20 @@
+---
+title: "Information Disclosure - Amazon S3 Bucket URL"
+alertid: 100036
+alertindex: 10003600
+alerttype: "Script Passive"
+alertcount: 1
+status: alpha
+type: alert
+risk: Low
+solution: "Remove S3 Bucket names from the response or ensure that the permissions in bucket are configured properly."
+other: ""
+cwe: 200
+wasc: 13
+alerttags: 
+  - CWE-200
+code: https://github.com/zaproxy/community-scripts/blob/main/passive/s3.js
+linktext: "passive/s3.js"
+help: https://www.zaproxy.org/docs/desktop/addons/community-scripts/
+---
+An Amazon S3 bucket URL was found in the HTTP response body.


### PR DESCRIPTION
Manually generate alert pages for script scan rules with the [`generate_alert_pages.js`](https://github.com/zaproxy/zap-admin/blob/master/scripts/generate_alert_pages.js) script.

A minor tweak was needed in the script (see https://github.com/zaproxy/zap-admin/pull/1187).