### PR TITLE
FAQ: Add alias for no-browser

### DIFF
--- a/site/content/faq/how-can-i-fix-browser-was-not-found.md
+++ b/site/content/faq/how-can-i-fix-browser-was-not-found.md
@@ -3,6 +3,8 @@ title: "How can I fix 'browser was not found'?"
 type: faq
 category: Howtos
 weight: 4
+aliases:
+  - no-browser/
 ---
 
 If you want to manually explore your target app then the easiest way is to launch your favourite browser


### PR DESCRIPTION
I'm about to PR a change to add this URL to warning messages.

Right now the user cant select and copy the text in a warning message (I'll look at fixing that in the core).

Until thats possible, https://www.zaproxy.org/faq/no-browser will be much easier to type than https://www.zaproxy.org/faq/how-can-i-fix-browser-was-not-found/ 😁 
