### PR TITLE
Tweak HoF link for GSoC 2019/2018 WebSockets Passive

### DIFF
--- a/site/data/studenthof.yaml
+++ b/site/data/studenthof.yaml
@@ -97,7 +97,7 @@
   title: Scanning websockets (phase 2)
   date: 2019 Summer
   links: >
-    <a href="https://manosmagnus.github.io/posts/websocket-passive-scan-using-scripts-with-zap/" rel="nofollow">Blog</a>,
+    <a href="https://web.archive.org/web/20210803233322/https://manosmagnus.github.io/posts/websocket-passive-scan-using-scripts-with-zap/" rel="nofollow">Blog</a>,
     <a href="https://github.com/zaproxy/zaproxy/wiki/GSoC2019_WebSocketScanning" rel="nofollow">wiki</a>
 
 - name: David Scrobonia

--- a/site/data/studenthof.yaml
+++ b/site/data/studenthof.yaml
@@ -128,7 +128,8 @@
   program: GSoC
   title: Scanning websockets (phase 1)
   date: 2018 Summer
-  links: 
+  links: >
+    <a href="https://web.archive.org/web/20201126054559/https://manosmagnus.github.io/posts/GSoC_18/" rel="nofollow">Blog</a>
 
 - name:  Ryan Wehe
   email: 


### PR DESCRIPTION
Switched URL to archive.org (Wayback Machine).
Per recent link check failures, ex: https://github.com/zaproxy/zaproxy-website/actions/runs/10650236424/job/29521359053