### PR TITLE
Convert SBOM addOn ID to lowercase in the breadcrumbs

### DIFF
--- a/site/layouts/sbom/single.html
+++ b/site/layouts/sbom/single.html
@@ -10,7 +10,7 @@
   <header class="breadcrumbs">
     <a href="/docs/">Docs</a> &gt;
     <a href="/docs/sbom/">SBOM</a> &gt;
-    <a href="/docs/sbom/{{ $addOn.id }}">{{ $addOn.name }}</a>
+    <a href="/docs/sbom/{{ $addOn.id | lower }}">{{ $addOn.name }}</a>
   </header>
   <br>
   <p>This page contains a list of all the libraries involved in building version <code>{{ $addOn.version }}</code> of the

--- a/site/layouts/shortcodes/addons.html
+++ b/site/layouts/shortcodes/addons.html
@@ -25,7 +25,7 @@
             {{end}}
             {{ $bomMdFilePath := print "docs/sbom/" .id ".md" }}
             {{ if os.FileExists $bomMdFilePath }}
-            <a class="no-border" title="SBOM" href="/docs/sbom/{{ .id }}" target="_blank" rel="noopener noreferrer"><img alt="SBOM" src="/img/addons/sbom.png" /></a>
+            <a class="no-border" title="SBOM" href="/docs/sbom/{{ .id | lower }}" target="_blank" rel="noopener noreferrer"><img alt="SBOM" src="/img/addons/sbom.png" /></a>
             {{end}}
             <br>
             {{ .description }}


### PR DESCRIPTION
Hi ZAP Team.
While checking for dead links in the zaproxy documentation, I noticed a similar 404 error on the SBOM page.

![](https://github.com/user-attachments/assets/363183db-90e7-41c4-bd29-944f71306521)

Specifically, in the breadcrumbs on [this page](https://www.zaproxy.org/docs/sbom/accesscontrol/), certain links are broken.

![](https://github.com/user-attachments/assets/f6e1b403-3ab6-4611-8615-50617703bc42)
![](https://github.com/user-attachments/assets/8dd80dc9-83a7-4177-a9fc-34a97cd8b400)

The breadcrumbs currently use the `$addOn.id` value directly, which includes mixed-case letters (e.g., accessControl). This creates URLs like `/docs/sbom/accessControl`, but the actual URL pattern is all lowercase, such as `/docs/sbom/accesscontrol`.

This PR updates `{{ $addOn.id }}` to `{{ $addOn.id | lower }}` so that the value is converted to lowercase, resolving the broken link issue.