### PR TITLE
Update docs to use blockquote alerts

### DIFF
--- a/site/content/docs/developer/quick-start-build.md
+++ b/site/content/docs/developer/quick-start-build.md
@@ -35,7 +35,8 @@ git clone https://github.com/zaproxy/zap-extensions.git
 ## Installing ZAP Add-ons
 As the name suggests, ZAP add-ons are a way to enhance ZAP functionality. There are several add-ons that allow you to do many different things. Some add-ons which are required by ZAP to work properly are called mandatory add-ons. These add-ons need to be installed first to be able to run ZAP from source.
 
-The *zap-extensions* repository contains the source code for the add-ons maintained by the core team, including the mandatory add-ons.
+> [!NOTE]
+> The *zap-extensions* repository contains the source code for the add-ons maintained by the core team, including the mandatory add-ons.
 
 ZAP uses the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) that downloads all the dependencies for the projects.
 


### PR DESCRIPTION
Follows up on PR #2977.

Per [my comment here](https://github.com/zaproxy/zaproxy-website/pull/2977#issuecomment-2697130494), the plan is to modify just the docs, not existing articles. (What needs to be highlighted will probably be obvious in some of the articles, but I was thinking there's a risk of highlighting wrongly in articles where I don't have adequate context.)

Please let me know if you have any preferences about how to approach this.