### PR TITLE
Remove Skyper's Twitter handle from authors

### DIFF
--- a/site/data/authors.yml
+++ b/site/data/authors.yml
@@ -131,7 +131,6 @@ zapbot:
 skyper:
   name: Paul-Emmanuel Raoul (a.k.a Skyper)
   picture: /img/authors/skyper_256x256.jpg
-  twitter: SkypLabs
   is_core: false
 
 keindel:


### PR DESCRIPTION
I, Skyper, have deleted my Twitter account, and switched to Mastodon.

By the way, having the possibility to add Mastodon links to author profiles would be great. I can create an issue for it if you want.