### PR TITLE
Improve hamburger mobile touch target and add aria-controls

### DIFF
--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -12,7 +12,7 @@
         <div class="hamburger-icon">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
         </div>
-        <input class="hamburger-click" aria-label="site menu" type="checkbox" />
+        <input class="hamburger-click" aria-label="toggle site menu" aria-controls="primary-menu" type="checkbox" />
         <ul id="primary-menu" class="flex">
           {{ $currentPage := . }}
           {{ range .Site.Menus.nav }}

--- a/src/css/_navigation.scss
+++ b/src/css/_navigation.scss
@@ -142,11 +142,13 @@
 
 .hamburger-click {
   cursor: pointer;
+  height: 45px;
+  width: 45px;
   opacity: 0.0;
   z-index: 2;
   position: absolute;
-  top: 36px;
-  right: 40px;
+  top: 20px;
+  right: 24px;
 }
 
 @media screen and (max-width: 1000px) {


### PR DESCRIPTION
## Description

 For the mobile navigation menu, the hamburger icon's click area appears much smaller than what [WCAG guidelines](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html) recommends for accessibility, which is a minimum of 44px height and width. I personally had difficulty attempting to toggle the menu on my mobile device; I couldn't consistently get it to open or close on each press.

**For this fix:**
- Add height and width sizing of 45px to the click area
- Readjust `top` and `right` values to ensure the area is centered with the hamburger icon SVG
- Add `aria-controls` to explicitly associate it with the navigation menu

The hamburger icon itself is rather small, so the clickable area is now a greater size and expands around it. This is acceptable from a UX-standpoint since there are no other buttons nearby that could accidently be pressed, and it is expected that this kind of input will be especially sensitive to trigger for ease of access.

You can test the fix out on this live demo [zaproxy.ritovision.com/](https://zaproxy.ritovision.com/).