### PR TITLE
Prevent broken page layout from table overflow

### DIFF
--- a/src/css/_page.scss
+++ b/src/css/_page.scss
@@ -22,7 +22,7 @@ a {
 }
 
 .bullet-list li {
-  margin-bottom: 0.6 rem;
+  margin-bottom: 0.6rem;
 }
 
 .bullet-list a {
@@ -30,10 +30,11 @@ a {
   text-decoration: none;
 }
 
+
 table {
   display: inline-block;
-  width: auto !important; 
-  max-width: 100%;   
+  width: auto !important;
+  max-width: 100%;
   overflow-x: auto;
   border-collapse: collapse;
 
@@ -41,7 +42,7 @@ table {
     border: solid 2px #eee;
 
     td, th {
-      padding:4px 8px;
+      padding: 4px 8px;
     }
   }
 }
@@ -50,18 +51,18 @@ table {
   table-layout: fixed;
 }
 
-table.table-fixed h5 { 
+table.table-fixed h5 {
   margin-bottom: 0px;
 }
 
 th {
   border-bottom: solid 3px var(--grey-light);
   padding: 4px 8px;
-  background:  var(--grey-light);
+  background: var(--grey-light);
 }
 
 th.sortable {
-	cursor: pointer;
+  cursor: pointer;
 }
 
 td {
@@ -143,7 +144,7 @@ $alert-colors: (
   padding: 0.8rem 1rem;
   background: rgba(0, 0, 0, 0.05);
   font-size: 1rem;
-  
+
   p {
     margin: 0;
   }

--- a/src/css/_tables.scss
+++ b/src/css/_tables.scss
@@ -1,0 +1,20 @@
+/* Table utilities and reusable patterns */
+
+.sticky-table {
+  max-height: 80vh;
+  overflow-y: auto;
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+  }
+}
+
+.market-table {
+  @extend .sticky-table;
+
+  .no-border {
+    border: none;
+  }
+}

--- a/src/css/pages/addons.scss
+++ b/src/css/pages/addons.scss
@@ -1,7 +1,1 @@
-.market-table {
-
-    .no-border {
-        border: none;
-    }
-}
-
+/* Page-specific styles for Add-ons live here. */


### PR DESCRIPTION
## Description

The tables throughout the site are not mobile responsive and cause horizontal page overflow when they're too wide to fit on the page. This breaks the layout on mobile and introduces difficulties scrolling around the page.

**This fix:**
* Modifies global table behavior to be horizontally scrollable internally instead of the page itself.
* Creates `_tables.scss` for table helper styles.
* Creates a `.sticky-table` class to allow tables' top row of cells to remain fixed for context while scrolling.
* Extends `.market-table` with `.sticky-table` so the top filter row is always accessible.
* Moves `.market-table` from `addons.scss` into `_tables.scss` since it is reused on multiple pages.

**Pages with tables that had page overflow:**
``/docs/internal-statistics/``
``/docs/internal-events/``
``/docs/constants/``
``/docs/alerts/``

You can test the fix out on this page of the demo site [zaproxy.ritovision.com/docs/constants/](https://zaproxy.ritovision.com/docs/constants)

### Before and After

Recorded on an Android Chrome browser, screen size about 450px.

**Before**

[zaproxy-tables-before_1.webm](https://github.com/user-attachments/assets/226a77b3-1d87-48d5-bbc6-60cdf16d421b)

**After**

[zaproxy-tables-after.webm](https://github.com/user-attachments/assets/603bb84a-d961-4225-af01-8646516aa29b)
