### PR TITLE
Add ZeroDAST to Third Party Products and Services

### DIFF
--- a/site/data/thirdparty.yaml
+++ b/site/data/thirdparty.yaml
@@ -130,6 +130,10 @@ services_oss:
     link: https://github.com/mercedes-benz/sechub
     license: 'Free, open source'
 
+  - name: 'ZeroDAST'
+    link: https://github.com/AlphaSudo/zerodast
+    license: 'Free, open source'
+
   # OWASP tools, open source, free, commercial tools, alphabetic
   - name: 'PurpleTeam-Labs'
     link: https://purpleteam-labs.com/


### PR DESCRIPTION
## Summary
Add ZeroDAST to the Third Party Products and Services page under the Open Source Projects section.

## Details
ZeroDAST is a free and open-source DAST automation project built on ~~OWASP~~ ZAP for GitHub Actions and REST API workflows.

## Changes
- Added ZeroDAST to site/data/thirdparty.yaml
- Kept the entry in alphabetical order under the open-source projects list

## Notes
I attempted a local site build after 
pm install, but on this Windows environment 
pm run build did not resolve imraf from 
ode_modules/.bin as expected. The content change itself is limited to a single YAML entry.