### PR TITLE
Scans - Option to flag FR results as n/a

### DIFF
--- a/site/content/docs/scans/firingrange.md
+++ b/site/content/docs/scans/firingrange.md
@@ -9,6 +9,8 @@ It is available online at https://public-firing-range.appspot.com/ and the GitHu
 
 It does not appear to be being actively maintained and some of the tests no longer appear to work with modern browsers. 
 
+Tests which we are sure are no longer valid are marked: "⚠️ No vuln" - if you can prove otherwise then please let us know!
+
 Click on the Sections to see the full set of results, which also link to the online test page and the scan rule which should find the vulnerability.
 
 

--- a/site/layouts/shortcodes/scan-results.html
+++ b/site/layouts/shortcodes/scan-results.html
@@ -30,17 +30,20 @@
     <tr class="scan-{{ $section }}" {{ if ne $expand "true" }} style="display: none" {{ end }}>
       {{ if $nolinks }}
       <td>{{ $test.path}}</td>
-      <td><a href="/docs/alerts/{{ $test.rule}}/">{{ $test.rule}}</a></td>
       {{ else }}
       <td><a href="{{ $data.url}}{{ $test.path}}">{{ $test.path}}</a></td>
-      <td><a href="/docs/alerts/{{ $test.rule}}/">{{ $test.rule}}</a></td>
       {{ end }}
+      {{ if eq $test.result "Broken" }}
+        <td><div class="scan-result-na">⚠️ No vuln</div></td>
+      {{ else }}
+        <td><a href="/docs/alerts/{{ $test.rule}}/">{{ $test.rule}}</a></td>
+      {{ end }} 
       {{ if eq $test.result "Pass" }} 
         <td><div class="scan-result-pass">&#10003; {{ $test.result}} </div></td>
         <td></td>
       {{ else if eq $test.result "Broken" }}
         <td></td>
-        <td><div class="scan-result-fail">⚠️ {{ $test.result}} </div></td>
+        <td></td>
       {{ else if eq $test.result "FAIL" }}
         <td></td>
         <td><div class="scan-result-fail">&#10060; {{ $test.result}} </div></td>

--- a/src/css/components/_scans.scss
+++ b/src/css/components/_scans.scss
@@ -1,3 +1,8 @@
+.scanResultsTable {
+  display: block;
+  width: 100% !important;
+}
+
 .scan-result-pass {
   color: green;
 }


### PR DESCRIPTION
Some of the Firing Range tests no longer appear to be exploitable. Show that in the results.
The actual results will be updated as per usual, with some scoring tweaks.

<img width="868" height="254" alt="image" src="https://github.com/user-attachments/assets/45534b59-31e0-4f72-a0be-c70a9ccb73dc" />
