### PR TITLE
docs: note Git Bash path conversion silently breaks the /zap/wrk mount

### DIFF
--- a/site/content/docs/docker/about.md
+++ b/site/content/docs/docker/about.md
@@ -91,6 +91,11 @@ Many environments _also_ support the $PWD / ${PWD} _environment variable_.
 
 Finding working solutions for _all_ environments is outside the scope of this document.
 
+> [!NOTE]
+> **Windows Git Bash / MSYS users:** Git Bash automatically converts POSIX-style paths in arguments to Windows paths. This mangles the container side of the `-v host:/zap/wrk` mount, so the volume silently fails to mount and the scan reports:
+> `A file based option has been specified but the directory '/zap/wrk' is not mounted`.
+> Work around it by prefixing the container path with an extra slash (`//zap/wrk/`), setting `MSYS_NO_PATHCONVERSION=1` for the command, or simply running the `docker run` command from PowerShell or CMD instead.
+
 ### Packaged Scans
 All of the docker images (apart from the 'bare' one) provide a set of packaged scan scripts:
 


### PR DESCRIPTION
When running the packaged scans (e.g. `zap-full-scan.py`) with `docker run -v <host>:/zap/wrk/:rw ...` from **Git Bash / MSYS on Windows**, the mount silently fails and the scan reports:

```
A file based option has been specified but the directory '/zap/wrk' is not mounted
```

The cause is not ZAP-specific: Git Bash automatically converts POSIX-style paths in command arguments to Windows paths, which mangles the container side of the `-v host:container` argument to `docker run`. This is a well-known MSYS behavior that affects any `docker run -v` invocation.

This PR adds a short `> [!NOTE]` callout to the "Mounting the Current Directory" section of the docker docs, next to the existing CWD mount examples, listing the three standard workarounds:

- prefix the container path with an extra slash (`//zap/wrk/`),
- set `MSYS_NO_PATHCONVERSION=1` for the command, or
- run the `docker run` command from PowerShell or CMD instead.

Docs-only change, single file (`site/content/docs/docker/about.md`).