### PR TITLE
Add blog age banner

### DIFF
--- a/site/content/blog/2023-02-01-authenticating-using-selenium/index.md
+++ b/site/content/blog/2023-02-01-authenticating-using-selenium/index.md
@@ -11,6 +11,12 @@ tags:
 date: "2023-02-01"
 authors: 
     - simon
+outdated:
+    notice: true
+    title: "This approach has been superseded"
+    message: "The authentication approach described here has been superseded."
+    link: "/docs/authentication/"
+    link_text: "Authentication Decision Tree"
 ---
 
 ![ZAPbot selenium authentication](images/selenium-auth.png)

--- a/site/content/blog/2023-08-01-zap-is-joining-the-software-security-project/index.md
+++ b/site/content/blog/2023-08-01-zap-is-joining-the-software-security-project/index.md
@@ -9,6 +9,10 @@ tags:
 date: "2023-08-01"
 authors:
     - simon
+outdated:
+    notice: true
+    title: "Historical content"
+    message: "This blog post has been kept for historical reasons. ZAP is now supported by Checkmarx and is not part of any foundation."
 ---
 I’m delighted to announce that ZAP is joining the new [Software Security Project](https://softwaresecurityproject.org/) (SSP) as one of the founding projects.
 

--- a/site/layouts/post/single.html
+++ b/site/layouts/post/single.html
@@ -19,15 +19,19 @@
               Posted <span class="post-date">{{ .Date.Format "Monday January 2, 2006" }}</span>
               <span class="word-count fl-r"> {{ .WordCount }} Words </span>
             </section>
-            {{ if lt .Date (now.AddDate -5 0 0) }}
+            {{ $outdated := .Params.outdated }}
+            {{ if not $outdated }}{{ $outdated = dict }}{{ end }}
+            {{ if or (eq $outdated.notice true) (and (lt .Date (now.AddDate -5 0 0)) (ne $outdated.notice false)) }}
             <blockquote class="alert alert-warning">
               <p class="alert-heading">
-                ⚠️ Content may be outdated
+                ⚠️ {{ $outdated.title | default "Content may be outdated" }}
               </p>
               <div class="alert-content">
                 <p>
-                  Posted over five years ago. Features and functionality described here may no longer match modern ZAP.
-                  Check the <a href="/">website</a> before following this content.
+                  {{ with $outdated.message }}{{ . | markdownify }}{{ else }}Features and functionality described here may no longer match modern ZAP.{{ end }}
+                  {{ if or $outdated.link (not $outdated.message) }}
+                  Check the <a href="{{ $outdated.link | default "/" }}">{{ $outdated.link_text | default "website" }}</a> before relying on this content.
+                  {{ end }}
                 </p>
               </div>
             </blockquote>

--- a/site/layouts/post/single.html
+++ b/site/layouts/post/single.html
@@ -19,6 +19,19 @@
               Posted <span class="post-date">{{ .Date.Format "Monday January 2, 2006" }}</span>
               <span class="word-count fl-r"> {{ .WordCount }} Words </span>
             </section>
+            {{ if lt .Date (now.AddDate -5 0 0) }}
+            <blockquote class="alert alert-warning">
+              <p class="alert-heading">
+                ⚠️ Content may be outdated
+              </p>
+              <div class="alert-content">
+                <p>
+                  Posted over five years ago. Features and functionality described here may no longer match modern ZAP.
+                  Check the <a href="/">website</a> before following this content.
+                </p>
+              </div>
+            </blockquote>
+            {{ end }}
             {{ .Content }}
           </main>
           <div class="next-content bg--blue-lightest p-10">


### PR DESCRIPTION
Per slack discussion.

<img width="1698" height="772" alt="image" src="https://github.com/user-attachments/assets/33d9ed0f-3b88-4b79-b704-b04086cb6de2" />

Note: This uses the same CSS etc as the download page notes about AV and signing.