### PR TITLE
Allow alert detail filters to exact match with quotes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,12 +31,17 @@ document.addEventListener("DOMContentLoaded", function() {
       labels: {}
     };
 
-    // Checks if row matches against filter
+    // Checks if row matches against filter.
+    // Surround value with double quotes for exact match, e.g. "Passive".
     function isFilterMatch(row) {
       for (const index in widget.filters) {
         const filter = widget.filters[index].toLowerCase();
         const rowValue = row.columns[index].toLowerCase();
-        if (rowValue.indexOf(filter) === -1) {
+        if (filter.length >= 2 && filter.startsWith('"') && filter.endsWith('"')) {
+          if (rowValue !== filter.slice(1, -1)) {
+            return false;
+          }
+        } else if (rowValue.indexOf(filter) === -1) {
           return false;
         }
       }


### PR DESCRIPTION
Add functionality to facilitate exact match filters leveraging quotes.

Ex:
- http://localhost:3000/docs/alerts/?status=alpha&type=%22Passive%22 ➡️  Exact match (Passive only) [%22 is URLEncoded double quote]
- http://localhost:3000/docs/alerts/?status=alpha&type=Passive ➡️ Contains match (Passive, Client Passive, Script Passive)